### PR TITLE
[feat] 기본 버튼, 라운드 버튼 컴포넌트

### DIFF
--- a/yum-yum/src/components/button/BasicButton.jsx
+++ b/yum-yum/src/components/button/BasicButton.jsx
@@ -1,0 +1,39 @@
+// 일반버튼 컴포넌트
+import React from 'react';
+import clsx from 'clsx';
+
+export default function BasicButton({
+  size = 'md', // sm, md, lg, xl, full
+  color = 'primary', // primary, secondary, gray
+  variant = 'filled', // filled, line
+  svg = null,
+  disabled = false,
+  onClick,
+  children,
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      // h-12 px-5 bg-emerald-500 rounded-lg inline-flex justify-center items-center gap-2 overflow-hidden
+      className={clsx('rounded flex justify-center items-center', {
+        'px-2 h-12': size === 'sm',
+        'px-5 h-12': size === 'md',
+        'px-8 h-12': size === 'lg',
+        'px-11 h-12': size === 'xl',
+        'w-full h-12': size === 'full',
+        'bg-primary text-white': color === 'primary' && variant === 'filled' && !disabled,
+        'bg-secondary text-white': color === 'secondary' && variant === 'filled' && !disabled,
+        'bg-gray-600 text-white': color === 'gray' && variant === 'filled' && !disabled,
+        'border border-primary text-primary':
+          color === 'primary' && variant === 'line' && !disabled,
+        'border border-secondary text-secondary':
+          color === 'secondary' && variant === 'line' && !disabled,
+        'border border-gray-600 text-gray-300': color === 'gray' && variant === 'line',
+        'bg-gray-300 text-white cursor-not-allowed': disabled,
+      })}
+    >
+      {children}
+    </button>
+  );
+}

--- a/yum-yum/src/components/button/BasicButton.jsx
+++ b/yum-yum/src/components/button/BasicButton.jsx
@@ -6,7 +6,6 @@ export default function BasicButton({
   size = 'md', // sm, md, lg, xl, full
   color = 'primary', // primary, secondary, gray
   variant = 'filled', // filled, line
-  svg = null,
   disabled = false,
   onClick,
   children,

--- a/yum-yum/src/components/button/FloatButton.jsx
+++ b/yum-yum/src/components/button/FloatButton.jsx
@@ -1,0 +1,48 @@
+// 플로팅 버튼 컴포넌트
+import React from 'react';
+import IconPlus from '@/assets/icons/icon-plus-line.svg?react';
+import IconClose from '@/assets/icons/icon-close.svg?react';
+import IconDrop from '@/assets/icons/icon-drop.svg?react';
+import IconMeal from '@/assets/icons/icon-restaurant.svg?react';
+import { useNavigate } from 'react-router-dom';
+
+export default function FloatButton({ onClick, isOpen, isClose, disabled }) {
+  const navigate = useNavigate();
+  return (
+    <>
+      {/* 플로팅 버튼 클릭했을 때 위에 뜨는 메뉴들 */}
+      {isOpen && (
+        <div className='fixed bottom-35 right-4 space-y-2 flex flex-col z-50'>
+          <button
+            onClick={() => {
+              navigate('/water');
+            }}
+            className='p-2 px-4 rounded bg-gray-800 rounded-full text-white shadow-lg flex justify-center items-center space-x-2'
+          >
+            <IconDrop className='w-6 h-6' />
+            <span className='pl-2'>물 추가하기</span>
+          </button>
+          <button
+            onClick={() => {}}
+            className='p-2 px-4 rounded bg-gray-800 rounded-full text-white shadow-lg flex justify-center items-center space-x-2'
+          >
+            <IconMeal className='w-6 h-6' />
+            <span className='pl-2'>식단 추가하기</span>
+          </button>
+        </div>
+      )}
+      {/* 플로팅 버튼 */}
+      <button
+        className='fixed bottom-20 right-4 p-3 rounded-full bg-primary text-white shadow-lg'
+        onClick={isClose}
+        disabled={disabled}
+      >
+        {isOpen ? (
+          <IconClose width='24' height='24' fill='#ffffff' />
+        ) : (
+          <IconPlus width='24' height='24' fill='#ffffff' />
+        )}
+      </button>
+    </>
+  );
+}

--- a/yum-yum/src/components/button/RoundButton.jsx
+++ b/yum-yum/src/components/button/RoundButton.jsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx';
+import React from 'react';
+
+export default function RoundButton({
+  size = 'md', // sm, md, lg, xl, full
+  color = 'primary', // primary, secondary, gray
+  variant = 'filled', // filled, line
+  svg = null,
+  disabled = false,
+  onClick,
+  children,
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={clsx('rounded-full flex justify-center items-center', {
+        'px-2 h-12': size === 'sm',
+        'px-5 h-12': size === 'md',
+        'px-8 h-12': size === 'lg',
+        'px-11 h-12': size === 'xl',
+        'w-full h-12': size === 'full',
+        'bg-primary text-white': color === 'primary' && variant === 'filled' && !disabled,
+        'bg-secondary text-white': color === 'secondary' && variant === 'filled' && !disabled,
+        'bg-gray-600 text-white': color === 'gray' && variant === 'filled' && !disabled,
+        'border border-primary text-primary':
+          color === 'primary' && variant === 'line' && !disabled,
+        'border border-secondary text-secondary':
+          color === 'secondary' && variant === 'line' && !disabled,
+        'border border-gray-600 text-gray-300': color === 'gray' && variant === 'line',
+        'bg-gray-300 text-white cursor-not-allowed': disabled,
+      })}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## 📝 작업 개요
- 공용 버튼 컴포넌트


## 🔨 작업 내용
- `BasicButton` : 기본 버튼
- `RoundButton` : 양쪽이 둥근 버튼
- 버튼 크기는 padding 을 이용하여 크기 변화를 주었습니다. 높이는 고정높이입니다.

## ✅ 테스트 방법
<img width="327" height="72" alt="스크린샷 2025-09-05 오전 10 53 11" src="https://github.com/user-attachments/assets/36079c5f-7302-4293-af7e-cf167651f86f" />
   
```jsx
// svg이미지를 추가할 때 children으로 보내집니다.
<RoundButton
          size='sm'
          color='primary'
          variant='filled'
          disabled={false}
          onClick={() => console.log('RoundButton clicked')}
        >
          <IconFat />
          라운드 버튼 sm
        </RoundButton>
        <RoundButton
          size='md'
          color='primary'
          variant='filled'
          disabled={false}
          onClick={() => console.log('RoundButton clicked')}
        >
          라운드 버튼 md
        </RoundButton>
```
### BasicButton
<img width="1346" height="382" alt="스크린샷 2025-09-05 오전 10 33 52" src="https://github.com/user-attachments/assets/6abc3756-708a-4442-b3aa-a86f6dca9d6f" />

### RoundButton
<img width="1348" height="402" alt="스크린샷 2025-09-05 오전 10 35 52" src="https://github.com/user-attachments/assets/3951e32d-3662-4112-9525-d9e6175c1b48" />



## 📎 관련 이슈
