### PR TITLE
[feat] 메시지 데이터 추가

### DIFF
--- a/yum-yum/src/data/message.js
+++ b/yum-yum/src/data/message.js
@@ -1,0 +1,22 @@
+// 일반 메시지들: 로딩, 필수입력 같은 (필요시 수정해서 사용해주세요.)
+
+export const COMMON_MESSAGES = {
+  loading: '잠시만 기다려주세요...',
+  error: {
+    network: '인터넷 연결을 확인해주세요.',
+    server: '서버에 문제가 발생했습니다',
+    auth: '로그인이 필요한 서비스입니다',
+    default: '다시 시도해주세요.',
+  },
+  success: {
+    save: '성공적으로 저장되었습니다!',
+    delete: '삭제되었습니다',
+    update: '업데이트 완료!',
+  },
+};
+
+export const VALIDATION_MESSAGES = {
+  required: '필수 입력 항목입니다',
+  email: '올바른 이메일 형식을 입력해주세요',
+  password: '비밀번호는 8자 이상이어야 합니다',
+};

--- a/yum-yum/src/data/motivateMessage.js
+++ b/yum-yum/src/data/motivateMessage.js
@@ -1,0 +1,7 @@
+/* 메인화면 칼로리 카드 메시지 */
+export const motiveMessage = {
+  empty: '첫 끼를 기록하고 상쾌한 하루를 시작해 보세요!',
+  undergoal: '남은 칼로리 ', // 남은칼로리 + 000kcal
+  donegoal: '축하해요! 오늘 목표 칼로리를 완벽하게 달성했어요!',
+  overgoal: '초과 칼로리 ', // 초과 칼로리 + 000kcal
+};


### PR DESCRIPTION
## 📝 작업 개요
- 지정되어있는 멘트 데이터 별도 보관

## 🔨 작업 내용
- 에러, 성공 등의 멘트 데이터 : `data/message.js`
     -  필요 시 수정해서 사용해주세요.
- 메인화면에서 쓰이는 칼로리 카드 멘트 : `data/motivateMessage.js`

## ✅ 테스트 방법
```js
import { COMMON_MESSAGES } from '@/data/message'

const TestPage = () => {
  return (
    <div>
      <p>{COMMON_MESSAGES.loading}</p>
    </div>
  )
}
```

## 📎 관련 이슈
