### PR TITLE
[feat] 리포트 페이지 UI 배치 및 날짜 관련 함수 추가

### DIFF
--- a/yum-yum/src/pages/report/AiReportPage.jsx
+++ b/yum-yum/src/pages/report/AiReportPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function AiReportPage() {
+  return (
+    <div>AiReportPage</div>
+  )
+}

--- a/yum-yum/src/pages/report/AiReportPage.jsx
+++ b/yum-yum/src/pages/report/AiReportPage.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
+
 export default function AiReportPage() {
+
   return (
     <div>AiReportPage</div>
   )

--- a/yum-yum/src/pages/report/ChartArea.jsx
+++ b/yum-yum/src/pages/report/ChartArea.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import RoundButton from './../../components/button/RoundButton';
+import RoundButton from '@/components/button/RoundButton';
 
 const periodPrefixConfig = {
   일간: '오늘의',
   주간: '이번 주 평균',
-  월간: '이번 달',
+  월간: '이번 달 평균',
 };
 
 const unitConfig = {

--- a/yum-yum/src/pages/report/ChartArea.jsx
+++ b/yum-yum/src/pages/report/ChartArea.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import RoundButton from '@/components/button/RoundButton';
+import PrevDateIcon from '@/assets/icons/icon-left.svg?react';
+import NextDateIcon from '@/assets/icons/icon-right.svg?react';
 
 const periodPrefixConfig = {
   일간: '오늘의',
@@ -24,13 +26,25 @@ const unitConfig = {
 
 const periods = ['일간', '주간', '월간'];
 
-export default function ChartArea({ date, unit, value, children, activePeriod, onPeriodChange }) {
+export default function ChartArea({ date, unit, value, children, activePeriod, onPeriodChange,
+  prevDate, nextDate  }) {
   const periodPrefix = periodPrefixConfig[activePeriod];
   const unitInfo = unitConfig[unit];
 
   return (
     <section className='flex flex-col items-center gap-7.5 py-5 border-t border-b border-gray-200 bg-[var(--color-primary-light)]'>
-      {date && <article className='text-2xl font-bold'>{date}</article>}
+      {date && (
+        <div className='flex flex-row gap-5 items-center'>
+          <button onClick={prevDate}>
+            <PrevDateIcon />
+          </button>
+
+          <article className='text-2xl font-bold'>{date}</article>
+          <button onClick={nextDate}>
+            <NextDateIcon />
+          </button>
+        </div>
+      )}
       {value && (
         <article className='flex items-end gap-2'>
           <span className='text-2xl font-bold'>

--- a/yum-yum/src/pages/report/ChartArea.jsx
+++ b/yum-yum/src/pages/report/ChartArea.jsx
@@ -32,7 +32,7 @@ export default function ChartArea({ date, unit, value, children, activePeriod, o
     <section className='flex flex-col items-center gap-7.5 py-5 border-t border-b border-gray-200 bg-[var(--color-primary-light)]'>
       {date && <article className='text-2xl font-bold'>{date}</article>}
       {value && (
-        <article className='flex items-center gap-2'>
+        <article className='flex items-end gap-2'>
           <span className='text-2xl font-bold'>
             {periodPrefix} {unitInfo.prefix} :{' '}
           </span>

--- a/yum-yum/src/pages/report/ChartArea.jsx
+++ b/yum-yum/src/pages/report/ChartArea.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import RoundButton from './../../components/button/RoundButton';
+
+const periodPrefixConfig = {
+  일간: '오늘의',
+  주간: '이번 주 평균',
+  월간: '이번 달',
+};
+
+const unitConfig = {
+  Kcal: {
+    prefix: '칼로리',
+    postfix: 'kcal',
+  },
+  L: {
+    prefix: '수분 섭취량',
+    postfix: 'L',
+  },
+  Kg: {
+    prefix: '몸무게',
+    postfix: 'Kg',
+  },
+};
+
+const periods = ['일간', '주간', '월간'];
+
+export default function ChartArea({ date, unit, value, children, activePeriod, onPeriodChange }) {
+  const periodPrefix = periodPrefixConfig[activePeriod];
+  const unitInfo = unitConfig[unit];
+
+  return (
+    <section className='flex flex-col items-center gap-7.5 py-5 border-t border-b border-gray-200 bg-[var(--color-primary-light)]'>
+      {date && <article className='text-2xl font-bold'>{date}</article>}
+      {value && (
+        <article className='flex items-center gap-2'>
+          <span className='text-2xl font-bold'>
+            {periodPrefix} {unitInfo.prefix} :{' '}
+          </span>
+          <span className='text-4xl font-bold'>{value}</span>
+          <span className='text-2xl font-bold'> {unitInfo.postfix}</span>
+        </article>
+      )}
+
+      {children}
+
+      <nav className='flex flex-row gap-4 py-2.5 justify-center'>
+        {periods.map((period) => (
+          <RoundButton
+            key={period}
+            onClick={() => onPeriodChange(period)}
+            variant={activePeriod === period ? 'filled' : 'line'}
+          >
+            {period}
+          </RoundButton>
+        ))}
+      </nav>
+    </section>
+  );
+}

--- a/yum-yum/src/pages/report/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/DietReportPage.jsx
@@ -1,30 +1,44 @@
 import React, { useEffect, useState } from 'react';
 import ChartArea from './ChartArea';
 import PieCharts from './charts/PieCharts';
+import { getDayOfWeekShort, todayDate } from '../../utils/dateUtils';
 
 export default function DietReportPage() {
   const [activePeriod, setActivePeriod] = useState('일간');
+  const [date, setDate] = useState(todayDate());
+  const day = getDayOfWeekShort(date);
+  const fullDate = date + ' (' + day + ')';
 
   useEffect(() => {
-    // console.log(activePeriod);
+    if (activePeriod === '일간') {
+      console.log('일간');
+    }
+
+    if (activePeriod === '주간') {
+      console.log('주간');
+    }
+
+    if (activePeriod === '월간') {
+      console.log('월간');
+    }
   }, [activePeriod]);
 
   const data = [
-  { name: '탄수화물', value: 400 },
-  { name: '단백질', value: 300 },
-  { name: '지방', value: 300 },
-];
+    { name: '탄수화물', value: 400 },
+    { name: '단백질', value: 300 },
+    { name: '지방', value: 300 },
+  ];
 
   return (
     <ChartArea
-      date={'08.28(목)'}
+      date={fullDate}
       period='일간'
       unit='Kcal'
       value='768'
       activePeriod={activePeriod}
       onPeriodChange={setActivePeriod}
     >
-      <PieCharts data={data}/> 
+      <PieCharts data={data} />
     </ChartArea>
   );
 }

--- a/yum-yum/src/pages/report/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/DietReportPage.jsx
@@ -1,7 +1,21 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react';
+import ChartArea from './ChartArea';
 
 export default function DietReportPage() {
+  const [activePeriod, setActivePeriod] = useState('일간');
+
+  useEffect(() => {
+    console.log(activePeriod);
+  }, [activePeriod]);
+
   return (
-    <div>DietReportPage</div>
-  )
+    <ChartArea
+      date={'08.28(목)'}
+      period='일간'
+      unit='Kcal'
+      value='768'
+      activePeriod={activePeriod}
+      onPeriodChange={setActivePeriod}
+    ></ChartArea>
+  );
 }

--- a/yum-yum/src/pages/report/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/DietReportPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import ChartArea from './ChartArea';
+import PieCharts from './charts/PieCharts';
 
 export default function DietReportPage() {
   const [activePeriod, setActivePeriod] = useState('일간');
@@ -7,6 +8,12 @@ export default function DietReportPage() {
   useEffect(() => {
     // console.log(activePeriod);
   }, [activePeriod]);
+
+  const data = [
+  { name: '탄수화물', value: 400 },
+  { name: '단백질', value: 300 },
+  { name: '지방', value: 300 },
+];
 
   return (
     <ChartArea
@@ -16,6 +23,8 @@ export default function DietReportPage() {
       value='768'
       activePeriod={activePeriod}
       onPeriodChange={setActivePeriod}
-    ></ChartArea>
+    >
+      <PieCharts data={data}/> 
+    </ChartArea>
   );
 }

--- a/yum-yum/src/pages/report/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/DietReportPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function DietReportPage() {
+  return (
+    <div>DietReportPage</div>
+  )
+}

--- a/yum-yum/src/pages/report/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/DietReportPage.jsx
@@ -1,27 +1,76 @@
 import React, { useEffect, useState } from 'react';
 import ChartArea from './ChartArea';
 import PieCharts from './charts/PieCharts';
-import { getDayOfWeekShort, todayDate } from '../../utils/dateUtils';
+import {
+  getDayOfWeek,
+  todayDate,
+  getStartDateOfWeek,
+  getEndDateOfWeek,
+  getYesterday,
+  getLastMonth,
+  getLastWeek,
+  getNextMonth,
+  getNextWeek,
+  getTomorrow,
+  parseDateString
+} from '@/utils/dateUtils';
 
 export default function DietReportPage() {
   const [activePeriod, setActivePeriod] = useState('일간');
   const [date, setDate] = useState(todayDate());
-  const day = getDayOfWeekShort(date);
-  const fullDate = date + ' (' + day + ')';
+  const day = getDayOfWeek(date);
 
-  useEffect(() => {
-    if (activePeriod === '일간') {
-      console.log('일간');
-    }
+  const getDisplayDate = (period, date, day) => {
+    const parsedDate = parseDateString(date);
 
-    if (activePeriod === '주간') {
-      console.log('주간');
+    switch (period) {
+      case '일간':
+        return `${parsedDate.month}월 ${parsedDate.date}일 (${day})`;
+      case '주간': {
+        const startDate = parseDateString(getStartDateOfWeek(date));
+        const endDate = parseDateString(getEndDateOfWeek(date));
+        return `${startDate.month}월 ${startDate.date}일 ~ ${endDate.month}월 ${endDate.date}일`;
+      }
+      case '월간':
+        return `${parsedDate.year}년 ${parsedDate.month}월`
+      default:
+        return date;
     }
+  };
 
-    if (activePeriod === '월간') {
-      console.log('월간');
+  const fullDate = getDisplayDate(activePeriod, date, day);
+
+  const handlePrevDate = () => {
+    switch (activePeriod) {
+      case '일간':
+        setDate(getYesterday(date));
+        break;
+      case '주간':
+        setDate(getLastWeek(date));
+        break;
+      case '월간':
+        setDate(getLastMonth(date));
+        break;
+      default:
+        return date;
     }
-  }, [activePeriod]);
+  };
+
+  const handleNextDate = () => {
+    switch (activePeriod) {
+      case '일간':
+        setDate(getTomorrow(date));
+        break;
+      case '주간':
+        setDate(getNextWeek(date));
+        break;
+      case '월간':
+        setDate(getNextMonth(date));
+        break;
+      default:
+        return date;
+    }
+  };
 
   const data = [
     { name: '탄수화물', value: 400 },
@@ -36,6 +85,8 @@ export default function DietReportPage() {
       unit='Kcal'
       value='768'
       activePeriod={activePeriod}
+      prevDate={handlePrevDate}
+      nextDate={handleNextDate}
       onPeriodChange={setActivePeriod}
     >
       <PieCharts data={data} />

--- a/yum-yum/src/pages/report/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/DietReportPage.jsx
@@ -5,7 +5,7 @@ export default function DietReportPage() {
   const [activePeriod, setActivePeriod] = useState('일간');
 
   useEffect(() => {
-    console.log(activePeriod);
+    // console.log(activePeriod);
   }, [activePeriod]);
 
   return (

--- a/yum-yum/src/pages/report/ReportPage.jsx
+++ b/yum-yum/src/pages/report/ReportPage.jsx
@@ -1,8 +1,43 @@
+import { useState } from 'react';
+import BasicButton from '@/components/button/BasicButton';
+import DietReportPage from './DietReportPage';
+import WaterReportPage from './WaterReportPage';
+import WeightReportPage from './WeightReportPage';
+import AiReportPage from './AiReportPage';
+
+const reportPath = {
+  '식단': DietReportPage,
+  '수분': WaterReportPage,
+  '체중': WeightReportPage,
+  'AI 리포트': AiReportPage,
+};
+
 
 export default function ReportPage() {
+  const [activeTab, setActiveTab] = useState('식단');
+  const reportTypes = [
+    { name: '식단' },
+    { name: '수분' },
+    { name: '체중' },
+    { name: 'AI 리포트' },
+  ];
+
+  const CurrentComponent = reportPath[activeTab];
+
   return (
-    <div className="bg-white">
-      <p>ReportPage</p>
+    <div className='bg-white'>
+      <section className='flex flex-row gap-4 py-2.5 justify-center'>
+        {reportTypes.map((type) => (
+          <BasicButton
+            key={type.name}
+            onClick={() => setActiveTab(type.name)}
+            variant={activeTab === type.name ? 'filled' : 'line'}
+          >{type.name}</BasicButton>
+        ))}
+      </section>
+      <main>
+        {CurrentComponent && <CurrentComponent />}
+      </main>
     </div>
   );
 }

--- a/yum-yum/src/pages/report/ReportPage.jsx
+++ b/yum-yum/src/pages/report/ReportPage.jsx
@@ -26,7 +26,7 @@ export default function ReportPage() {
 
   return (
     <div className='bg-white'>
-      <section className='flex flex-row gap-4 py-2.5 justify-center'>
+      <nav className='flex flex-row gap-4 py-2.5 justify-center'>
         {reportTypes.map((type) => (
           <BasicButton
             key={type.name}
@@ -34,7 +34,7 @@ export default function ReportPage() {
             variant={activeTab === type.name ? 'filled' : 'line'}
           >{type.name}</BasicButton>
         ))}
-      </section>
+      </nav>
       <main>
         {CurrentComponent && <CurrentComponent />}
       </main>

--- a/yum-yum/src/pages/report/WaterReportPage.jsx
+++ b/yum-yum/src/pages/report/WaterReportPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function WaterReportPage() {
+  return (
+    <div>WaterReportPage</div>
+  )
+}

--- a/yum-yum/src/pages/report/WeightReportPage.jsx
+++ b/yum-yum/src/pages/report/WeightReportPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function WeightReportPage() {
+  return (
+    <div>WeightReportPage</div>
+  )
+}

--- a/yum-yum/src/pages/report/charts/PieCharts.jsx
+++ b/yum-yum/src/pages/report/charts/PieCharts.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { PieChart, Pie, Cell, Legend } from 'recharts';
+
+export default function PieCharts({ data = [] }) {
+  const PALETTES = ['#FF5094', '#2F73E5', '#FFD653', '#FF8042'];
+
+  const chartData =
+    data.length > 0
+      ? data
+      : [
+          { name: '탄수화물', value: 0 },
+          { name: '단백질', value: 0 },
+          { name: '지방', value: 0 },
+        ];
+
+  // 합계 계산
+  const total = chartData.reduce((sum, d) => sum + d.value, 0);
+
+  // 파이 차트에 사용할 데이터. 데이터가 없을 때 따로 처리
+  const pieData =
+    total === 0
+      ? chartData.map((d) => ({ ...d, value: 1 })) // 0일 땐 균등하게 1씩
+      : chartData;
+
+  const renderCustomizedLabel = ({
+    cx,
+    cy,
+    midAngle,
+    innerRadius,
+    outerRadius,
+    percent,
+    value,
+  }) => {
+    const RADIAN = Math.PI / 180;
+    const radius = innerRadius + (outerRadius - innerRadius) * 0.5; // 안쪽 절반 지점
+    const x = cx + radius * Math.cos(-midAngle * RADIAN);
+    const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+    return (
+      <text x={x} y={y} fill='white' textAnchor='middle' dominantBaseline='central' fontSize={16}>
+        {total === 0 ? '0%' : `${(percent * 100).toFixed(0)}%`}
+      </text>
+      // 값이 없을때 0% 표기
+    );
+  };
+
+  return (
+    <PieChart width={400} height={320}>
+      <Pie
+        data={pieData}
+        cx='50%'
+        cy='45%'
+        labelLine={false}
+        outerRadius={120}
+        dataKey='value'
+        label={renderCustomizedLabel} // 커스텀 라벨 적용
+      >
+        {pieData.map((entry, index) => (
+          <Cell key={`cell-${index}`} fill={PALETTES[index % PALETTES.length]} />
+        ))}
+      </Pie>
+
+      <Legend
+        layout='horizontal'
+        verticalAlign='bottom'
+        align='center'
+        payload={pieData.map((item, index) => ({
+          value: item.name,
+          type: 'square', // 범례 도형
+          color: PALETTES[index % PALETTES.length],
+        }))}
+        wrapperStyle={{
+          whiteSpace: 'nowrap', // 줄바꿈 방지
+          marginTop: 20,
+          fontSize: 18,
+        }}
+        formatter={(value) => {
+          const item = chartData.find((d) => d.name === value);
+          return `${value} (${item?.value ?? 0})`;
+        }}
+      />
+    </PieChart>
+  );
+}

--- a/yum-yum/src/pages/report/charts/PieCharts.jsx
+++ b/yum-yum/src/pages/report/charts/PieCharts.jsx
@@ -45,7 +45,7 @@ export default function PieCharts({ data = [] }) {
   };
 
   return (
-    <PieChart width={400} height={320}>
+    <PieChart width={400} height={330}>
       <Pie
         data={pieData}
         cx='50%'

--- a/yum-yum/src/pages/report/charts/PieCharts.jsx
+++ b/yum-yum/src/pages/report/charts/PieCharts.jsx
@@ -67,16 +67,21 @@ export default function PieCharts({ data = [] }) {
         payload={pieData.map((item, index) => ({
           value: item.name,
           type: 'square', // 범례 도형
-          color: PALETTES[index % PALETTES.length],
         }))}
         wrapperStyle={{
           whiteSpace: 'nowrap', // 줄바꿈 방지
           marginTop: 20,
           fontSize: 18,
+          fontWeight: 800,
         }}
         formatter={(value) => {
           const item = chartData.find((d) => d.name === value);
-          return `${value} (${item?.value ?? 0})`;
+          return (
+            <div className='inline-block text-center w-20 align-middle text-black'>
+              <div>{value}</div>
+              <div className='mt-1'>{item?.value ?? 0}g</div>
+            </div>
+          );
         }}
       />
     </PieChart>

--- a/yum-yum/src/utils/dateUtils.js
+++ b/yum-yum/src/utils/dateUtils.js
@@ -1,0 +1,24 @@
+import { format, parse } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+const today = new Date();
+const dateFormat = 'yyyy년 MM월 dd일';
+
+function dateFormatting(date) {
+  return format(date, dateFormat, { locale: ko });
+}
+
+function parseDate(date) {
+  return parse(date, dateFormat, new Date());
+}
+
+// ----
+
+export function todayDate() {
+  return dateFormatting(today)
+}
+
+export function getDayOfWeekShort(date) {
+  const newDate = parseDate(date)
+  return format(newDate, 'E', { locale: ko }); 
+}

--- a/yum-yum/src/utils/dateUtils.js
+++ b/yum-yum/src/utils/dateUtils.js
@@ -1,4 +1,18 @@
-import { format, parse } from 'date-fns';
+import {
+  format,
+  parse,
+  getWeekOfMonth as getWeekOfMonthFns,
+  startOfWeek,
+  endOfWeek,
+  getMonth,
+  subDays,
+  subWeeks,
+  subMonths,
+  endOfMonth,
+  addDays,
+  addWeeks,
+  addMonths,
+} from 'date-fns';
 import { ko } from 'date-fns/locale';
 
 const today = new Date();
@@ -14,11 +28,102 @@ function parseDate(date) {
 
 // ----
 
+// 오늘
 export function todayDate() {
-  return dateFormatting(today)
+  return dateFormatting(today);
 }
 
-export function getDayOfWeekShort(date) {
-  const newDate = parseDate(date)
-  return format(newDate, 'E', { locale: ko }); 
+// 요일
+export function getDayOfWeek(date) {
+  const newDate = parseDate(date);
+  return format(newDate, 'E', { locale: ko });
 }
+
+// 몇번째 주인지
+export function getWeekOfMonth(date) {
+  const newDate = parseDate(date);
+  return getWeekOfMonthFns(newDate);
+}
+
+// 몇 월인지
+export function getMonths(date) {
+  const newDate = parseDate(date);
+  return getMonth(newDate);
+}
+
+// 이번주 시작 날짜
+export function getStartDateOfWeek(date) {
+  const newDate = parseDate(date);
+  return dateFormatting(startOfWeek(newDate));
+}
+
+// 이번주 종료 날짜
+export function getEndDateOfWeek(date) {
+  const newDate = parseDate(date);
+  return dateFormatting(endOfWeek(newDate));
+}
+
+// ---
+
+// 전날
+export function getYesterday(date) {
+  const newDate = parseDate(date);
+  return dateFormatting(subDays(newDate, 1));
+}
+
+// 다음날
+export function getTomorrow(date) {
+  const newDate = parseDate(date);
+  return dateFormatting(addDays(newDate, 1));
+}
+
+// 전 주
+export function getLastWeek(date) {
+  const newDate = parseDate(date);
+  const lastWeek = subWeeks(newDate, 1);
+  const lastWeekEnd = endOfWeek(lastWeek, { locale: ko });
+
+  return dateFormatting(lastWeekEnd);
+}
+
+// 다음 주
+export function getNextWeek(date) {
+  const newDate = parseDate(date);
+  const nextWeek = addWeeks(newDate, 1);
+  const NextWeekend = endOfWeek(nextWeek, { locale: ko });
+
+  return dateFormatting(NextWeekend);
+}
+
+// 이전달
+export function getLastMonth(date) {
+  const newDate = parseDate(date);
+  const lastMonth = subMonths(newDate, 1);
+  const lastMonthEnd = endOfMonth(lastMonth);
+  return dateFormatting(lastMonthEnd);
+}
+
+// 다음달
+export function getNextMonth(date) {
+  const newDate = parseDate(date);
+  const nextMonth = addMonths(newDate, 1);
+  const NextMonthEnd = endOfMonth(nextMonth);
+  return dateFormatting(NextMonthEnd);
+}
+
+// ---
+
+// 년 월 일 추출
+export const parseDateString = (dateString) => {
+  const regex = /(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일/;
+  const match = dateString.match(regex);
+
+  const [full, year, month, date] = match;
+
+  return {
+    year,
+    month: month.padStart(2, '0'), 
+    date: date.padStart(2, '0'),
+    fullDate: `${year}년 ${month.padStart(2, '0')}월 ${date.padStart(2, '0')}일`,
+  };
+};


### PR DESCRIPTION
## 📝 작업 개요
- 리포트 페이지 컴포넌트 생성
- 파이 차트 컴포넌트 추가
- 날짜 관련 함수를 추가 - 다른 리포트에서도 활용할 수 있도록 함

## 🔨 작업 내용
- 리포트 페이지 중, 식단 페이지 UI 배치
- date-fns를 활용한 날짜 관련 함수를 추가

## ✅ 테스트 방법
- 리포트 페이지에서 일간/주간/월간 버튼 및 날짜 변경 버튼을 클릭하여 잘 바뀌는지 확인하기

## 🎯 리뷰 요구사항
> 현재 일간/주간/월간 변경 시, 해당 단위 기간의 마지막 날이 날짜로 저장됩니다.
>  ex) 월간에서 8월로 변경 -> 일간으로 전환시 8월 31일 표시
> 계속 마지막 날로 저장을 할지, 첫 날로 저장할지 고민이 됩니다.
