### PR TITLE
[feat] 식단 기록 페이지 UI

### DIFF
--- a/yum-yum/src/App.jsx
+++ b/yum-yum/src/App.jsx
@@ -14,6 +14,9 @@ import SimpleLayout from '@/components/layout/SimpleLayout';
 import Layout from '@/components/layout/Layout';
 import RequireGuest from '@/routes/RequireGuest';
 import RequireAuth from '@/routes/RequireAuth';
+import CustomEntryForm from './pages/meal/page/CustomEntryForm';
+import TotalMeal from './pages/meal/page/TotalMeal';
+// import SearchList from './pages/meal/page/SearchList';
 
 const router = createBrowserRouter([
   {
@@ -29,6 +32,9 @@ const router = createBrowserRouter([
         children: [
           { index: true, element: <HomePage /> },
           { path: 'meal', element: <MealPage /> },
+          { path: 'meal/custom', element: <CustomEntryForm /> },
+          // { path: 'meal/search', element: <SearchList /> },
+          { path: 'meal/total', element: <TotalMeal /> },
           { path: 'report', element: <ReportPage /> },
           { path: 'water', element: <WaterPage /> },
         ],

--- a/yum-yum/src/components/EmptyState.jsx
+++ b/yum-yum/src/components/EmptyState.jsx
@@ -2,15 +2,19 @@ import React from 'react';
 // 아이콘
 import NoResultIcon from '@/assets/icons/icon-noresult.svg?react';
 
-export default function EmptyState({ children = 'Not Found' }) {
+export default function EmptyState({ children = 'Not Found', className = '' }) {
   const isDefault = children === 'Not Found';
+  const isStyle = className === '';
+
   return (
-    <div className='flex flex-col gap-7 items-center justify-center h-[calc(100vh-180px)]'>
+    <div
+      className={`flex flex-col gap-7 items-center justify-center ${isStyle ? 'h-screen' : className}`}
+    >
       <div className='flex items-center justify-center'>
         <NoResultIcon />
       </div>
 
-      <p className={`text-gray-500 ${isDefault ? 'text-4xl font-bold' : 'text-md font-normal'}`}>
+      <p className={`text-gray-500 ${isDefault ? 'text-4xl font-bold' : 'text-md font-semibold'}`}>
         {children}
       </p>
     </div>

--- a/yum-yum/src/components/button/BasicButton.jsx
+++ b/yum-yum/src/components/button/BasicButton.jsx
@@ -15,7 +15,7 @@ export default function BasicButton({
       onClick={onClick}
       disabled={disabled}
       // h-12 px-5 bg-emerald-500 rounded-lg inline-flex justify-center items-center gap-2 overflow-hidden
-      className={clsx('rounded flex justify-center items-center', {
+      className={clsx('rounded-lg flex justify-center items-center', {
         'px-2 h-12': size === 'sm',
         'px-5 h-12': size === 'md',
         'px-8 h-12': size === 'lg',

--- a/yum-yum/src/components/common/Input.jsx
+++ b/yum-yum/src/components/common/Input.jsx
@@ -15,7 +15,7 @@ export default function Input({
   ...rest
 }) {
   return (
-    <div className='flex flex-col gap-1'>
+    <div className='flex flex-col gap-1 w-full'>
       <div className='relative'>
         <input
           id={id}
@@ -42,7 +42,6 @@ export default function Input({
             {endAdornment}
           </button>
         )}
-
       </div>
 
       {status === 'error' && errorMessage && (

--- a/yum-yum/src/pages/meal/MealPage.jsx
+++ b/yum-yum/src/pages/meal/MealPage.jsx
@@ -1,9 +1,106 @@
-import React from 'react';
+import React, { useState } from 'react';
+// 컴포넌트
+import MealHeader from './component/MealHeader';
+import MealTabs from './component/MealTabs';
+import FrequentlyEatenFood from './page/FrequentlyEatenFood';
+import CustomEntry from './page/CustomEntry';
+import BasicButton from '@/components/button/BasicButton';
+import { useNavigate } from 'react-router-dom';
 
+const tabItem = [
+  { id: 'frequent', label: '자주 먹은 음식' },
+  { id: 'custom', label: '직접 등록' },
+];
 export default function MealPage() {
+  const [activeTab, setActiveTab] = useState('frequent');
+  const [searchInputValue, setSearchInputValue] = useState('');
+  const [searchFood, setSearchFood] = useState('');
+  const navigate = useNavigate();
+
+  const onSearchChange = (e) => {
+    setSearchInputValue(e.target.value);
+  };
+
+  // 돋보기 아이콘 클릭, 엔터
+  const handleSearchSubmit = () => {
+    console.log(searchInputValue);
+  };
+
+  // 기록하기 버튼
+  const handleRecord = () => {
+    navigate('/meal/total');
+  };
+
   return (
     <div>
-      <p>MealPage : 이부분은 지워주세요</p>
+      <MealHeader
+        variant='search'
+        value={searchInputValue}
+        onChange={onSearchChange}
+        handleSearchSubmit={handleSearchSubmit}
+      />
+
+      <MealTabs activeTabId={activeTab} onChange={setActiveTab} tabItem={tabItem} />
+      {activeTab === 'frequent' ? <FrequentlyEatenFood /> : <CustomEntry />}
+
+      <div className='sticky bottom-0 z-30 block w-full max-w-[500px] p-[20px] bg-white'>
+        <BasicButton size='full' onClick={handleRecord}>
+          기록하기
+        </BasicButton>
+      </div>
     </div>
   );
 }
+
+// pages/Meal/MealPage.jsx
+// import React, { useState } from 'react';
+// import { fetchMfds } from '../../services/mfds';
+// import MealHeader from './component/MealHeader';
+// import SearchList from './page/SearchList';
+// import { useNavigate } from 'react-router-dom';
+
+// export default function MealPage() {
+//   const [searchInputValue, setSearchInputValue] = useState('');
+//   const [items, setItems] = useState([]); // ✅ 결과 상태
+//   const [loading, setLoading] = useState(false);
+//   const [errMsg, setErrMsg] = useState('');
+//   const navigate = useNavigate();
+
+//   const onSearchChange = (e) => setSearchInputValue(e.target.value);
+
+//   const handleSearchSubmit = async () => {
+//     const q = searchInputValue.trim();
+//     if (!q) return;
+//     setLoading(true);
+//     setErrMsg('');
+//     try {
+//       const data = await fetchMfds(q); // ✅ 검색어 전달
+//       setItems(data); // ✅ 결과 반영
+//       console.log('[MealPage] items=', data.length);
+//     } catch (e) {
+//       console.error(e);
+//       setErrMsg(e?.message || '요청 실패');
+//     } finally {
+//       setLoading(false);
+//     }
+//   };
+
+//   const handleRecord = () => navigate('/meal/total');
+
+//   return (
+//     <div>
+//       <MealHeader
+//         variant='search'
+//         value={searchInputValue}
+//         onChange={onSearchChange}
+//         handleSearchSubmit={handleSearchSubmit}
+//       />
+
+//       {loading && <div className='px-[20px] text-gray-600'>불러오는 중…</div>}
+//       {errMsg && <div className='px-[20px] text-red-600'>에러: {errMsg}</div>}
+
+//       {/* ✅ 결과 내려주기 */}
+//       <SearchList items={items} />
+//     </div>
+//   );
+// }

--- a/yum-yum/src/pages/meal/component/FoodDetailModal.jsx
+++ b/yum-yum/src/pages/meal/component/FoodDetailModal.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+// 컴포넌트
+import Modal from '@/components/Modal';
+export default function FoodDetailModal({ openModal, closeModal, foodInfo }) {
+  const title = foodInfo?.foodName;
+
+  return (
+    <Modal isOpenModal={openModal} onCloseModal={closeModal} title={title} btnLabel='추가하기'>
+      <div>
+        <div className='py-[20px] border-t border-gray-200'>
+          <div className='flex justify-between text-sm'>
+            <h5>탄수화물</h5>
+            <p className='font-bold'>10.2g</p>
+          </div>
+
+          <div className='flex flex-col gap-[12px] pt-[20px]'>
+            <div className='flex justify-between pl-[20px] text-sm text-gray-500'>
+              <h6>- 당</h6>
+              <p className='font-bold'>10.2g</p>
+            </div>
+            <div className='flex justify-between pl-[20px] text-sm text-gray-500'>
+              <h6>- 당</h6>
+              <p className='font-bold'>10.2g</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/yum-yum/src/pages/meal/component/FoodItem.jsx
+++ b/yum-yum/src/pages/meal/component/FoodItem.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+// 아이콘
+import PlusIcon from '@/assets/icons/icon-plus.svg?react';
+import MinusIcon from '@/assets/icons/icon-minus.svg?react';
+import CheckIcon from '@/assets/icons/icon-check.svg?react';
+
+export default function FoodItem({
+  id,
+  foodName,
+  makerName,
+  foodWeight,
+  foodCal,
+  variant = 'select' /* select, delete */,
+  selected = false,
+  onToggleSelect,
+  onDelete,
+  onClick,
+}) {
+  const handleSelected = (e) => {
+    e.stopPropagation();
+    onToggleSelect?.();
+  };
+
+  const handleDelete = (e) => {
+    e.stopPropagation();
+    onDelete();
+  };
+  return (
+    <li
+      onClick={onClick}
+      className='flex justify-between items-center py-5 border-b border-gray-200'
+    >
+      <div className='flex flex-col gap-1'>
+        <h5>{foodName}</h5>
+
+        <div className='flex gap-1 text-sm'>
+          {makerName && <p className='text-gray-700'>{makerName}</p>}
+          <p className='text-gray-400'>1잔 ({foodWeight}ml)</p>
+        </div>
+      </div>
+
+      <div className='flex gap-3'>
+        {/* 칼로리 */}
+        <div className='font-bold text-gray-500'>{foodCal}kcal</div>
+
+        <div className='flex items-center justify-center'>
+          {variant === 'select' && (
+            <button onClick={handleSelected} className='flex items-center justify-center'>
+              {selected ? (
+                <CheckIcon className='text-primary' />
+              ) : (
+                <PlusIcon className='text-[#CBE9DB] w-[24px] h-[24px]' />
+              )}
+            </button>
+          )}
+
+          {variant === 'delete' && (
+            <button onClick={handleDelete} className='flex items-center justify-center'>
+              <MinusIcon className='text-primary w-[24px] h-[24px]' />
+            </button>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/yum-yum/src/pages/meal/component/FoodList.jsx
+++ b/yum-yum/src/pages/meal/component/FoodList.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+// 컴포넌트
+import FoodItem from './FoodItem';
+import FoodDetailModal from './FoodDetailModal';
+
+export default function FoodList({
+  items = [],
+  variant = 'select',
+  selectedIds = [],
+  onToggleSelect,
+  onDelete,
+}) {
+  const [openModal, setOpenModal] = useState(false);
+  const [selectedFood, setSelectedFood] = useState(null);
+
+  const isSelected = (id) => selectedIds.includes(id);
+
+  const open = (food) => {
+    setSelectedFood(food);
+    setOpenModal(true);
+  };
+
+  return (
+    <div>
+      <ul>
+        {items.map((food) => (
+          <FoodItem
+            key={food.id}
+            id={food.id}
+            foodName={food.foodName}
+            makerName={food.makerName}
+            foodWeight={food.foodWeight}
+            foodCal={food.foodCal}
+            onClick={() => open(food)}
+            variant={variant}
+            selected={variant === 'select' ? isSelected(food.id) : false}
+            onToggleSelect={onToggleSelect ? () => onToggleSelect(food.id) : undefined}
+            onDelete={onDelete ? () => onDelete(food.id) : undefined}
+          />
+        ))}
+      </ul>
+      <FoodDetailModal
+        openModal={openModal}
+        closeModal={() => setOpenModal(false)}
+        foodInfo={selectedFood}
+      />
+    </div>
+  );
+}

--- a/yum-yum/src/pages/meal/component/MealHeader.jsx
+++ b/yum-yum/src/pages/meal/component/MealHeader.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+// 아이콘
+import PrevIcon from '@/assets/icons/icon-left.svg?react';
+import SearchIcon from '@/assets/icons/icon-search.svg?react';
+
+export default function FoodSearch({
+  variant = 'title',
+  children,
+  isRight = false,
+  value,
+  onChange,
+  handleSearchSubmit,
+}) {
+  const navigate = useNavigate();
+  const handleBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <div className='sticky top-0 z-30 flex justify-center items-center h-[60px] px-5 py-2 bg-white'>
+      <button onClick={handleBack} className='absolute left-[20px] flex items-center'>
+        <PrevIcon className='h-[44px] mr-4' />
+      </button>
+
+      {variant === 'title' ? (
+        <h2 className='font-bold text-lg'>{children}</h2>
+      ) : (
+        <div className='flex items-center gap-3 w-full ml-[26px] px-4 bg-gray-100 rounded-full '>
+          <button onClick={handleSearchSubmit} className='flex items-center justify-center'>
+            <SearchIcon />
+          </button>
+
+          <input
+            type='text'
+            placeholder='음식 검색'
+            value={value}
+            onChange={onChange}
+            className='w-full h-[44px] outline-none'
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSearchSubmit();
+            }}
+          />
+        </div>
+      )}
+
+      {isRight && (
+        <span className='absolute right-[20px] text-sm text-gray-500'>
+          <strong className='text-secondary'>*</strong> 필수 입력
+        </span>
+      )}
+    </div>
+  );
+}

--- a/yum-yum/src/pages/meal/component/MealTabs.jsx
+++ b/yum-yum/src/pages/meal/component/MealTabs.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function MealTabs({ activeTabId, onChange, tabItem }) {
+  return (
+    <div className='flex'>
+      {tabItem.map((tab) => (
+        <button
+          key={tab.id}
+          type='button'
+          onClick={() => onChange(tab.id)}
+          className={`w-full py-4 text-center cursor-pointer text-gray-800 font-bold text-md ${
+            activeTabId === tab.id ? 'border-b-2 border-primary' : 'border-b-2 border-white'
+          }`}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/yum-yum/src/pages/meal/component/NutritionSection.jsx
+++ b/yum-yum/src/pages/meal/component/NutritionSection.jsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import Input from '../../../components/common/Input';
+
+export default function NutritionSection() {
+  const [values, setValues] = useState({
+    kcal: '',
+    carbs: '',
+    sugar: '',
+    sweetener: '',
+    fiber: '',
+    protein: '',
+    fat: '',
+    satFat: '',
+    transFat: '',
+    unsatFat: '',
+    cholesterol: '',
+    sodium: '',
+    potassium: '',
+    caffeine: '',
+  });
+
+  const set = (id) => (e) => setValues((prev) => ({ ...prev, [id]: e.target.value }));
+
+  const nutritionFields = [
+    { type: 'row', label: '칼로리', id: 'kcal', unit: 'kcal', required: true },
+
+    { type: 'row', label: '탄수화물', id: 'carbs', unit: 'g' },
+    { type: 'row', label: '- 당', id: 'sugar', unit: 'g', subtle: true },
+    { type: 'row', label: '- 대체 감미료', id: 'sweetener', unit: 'g', subtle: true },
+    { type: 'row', label: '- 식이섬유', id: 'fiber', unit: 'g', subtle: true },
+
+    { type: 'row', label: '단백질', id: 'protein', unit: 'g' },
+
+    { type: 'row', label: '지방', id: 'fat', unit: 'g' },
+    { type: 'row', label: '- 포화지방', id: 'satFat', unit: 'g', subtle: true },
+    { type: 'row', label: '- 트랜스지방', id: 'transFat', unit: 'g', subtle: true },
+    { type: 'row', label: '- 불포화지방', id: 'unsatFat', unit: 'g', subtle: true },
+
+    { type: 'row', label: '콜레스테롤', id: 'cholesterol', unit: 'mg' },
+    { type: 'row', label: '나트륨', id: 'sodium', unit: 'mg' },
+    { type: 'row', label: '칼륨', id: 'potassium', unit: 'mg' },
+    { type: 'row', label: '카페인', id: 'caffeine', unit: 'mg' },
+  ];
+
+  return (
+    <div>
+      <label className='font-bold' htmlFor='nutrition'>
+        영양정보
+      </label>
+
+      <div>
+        {nutritionFields.map((f) => (
+          <div
+            key={f.id}
+            className={`flex gap-2 items-center py-[12px] text-sm first:border-t-0 border-t border-gray-300 ${f.subtle ? 'border-none' : ''}`}
+          >
+            <label
+              className={`w-full max-w-[226px] ${f.subtle ? 'pl-[20px] text-gray-500' : ''}`}
+              htmlFor={f.id}
+            >
+              {f.label} {f.required && <strong className='font-extrabold text-secondary'>*</strong>}
+            </label>
+            <Input
+              id={f.id}
+              value={values[f.id]}
+              onChange={set(f.id)}
+              endAdornment={f.unit}
+              placeholder='0'
+              maxLength={8}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/yum-yum/src/pages/meal/page/CustomEntry.jsx
+++ b/yum-yum/src/pages/meal/page/CustomEntry.jsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+// 컴포넌트
+import EmptyState from '@/components/EmptyState';
+// 아이콘
+import SearchIcon from '@/assets/icons/icon-search.svg?react';
+import FoodList from '../component/FoodList';
+
+const foodItems = [
+  {
+    id: '1',
+    foodName: '두유',
+    makerName: '',
+    foodWeight: '200',
+    foodCal: '110',
+  },
+  {
+    id: '2',
+    foodName: '약콩두유',
+    makerName: '대학두유',
+    foodWeight: '190',
+    foodCal: '100',
+  },
+  {
+    id: '3',
+    foodName: '약콩두유',
+    makerName: '대학두유',
+    foodWeight: '190',
+    foodCal: '100',
+  },
+];
+
+export default function CustomEntry() {
+  const [selectedIds, setSelectedIds] = useState([]);
+  const handleToggleSelect = (id) => {
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+    console.log(id);
+  };
+  return (
+    <div className='flex flex-col h-full'>
+      <div className='flex justify-between items-center px-5 py-3 bg-gray-50'>
+        {/* 직접 등록 버튼 */}
+        <div className='flex gap-2 items-center'>
+          <div className='flex items-center justify-center'>
+            <SearchIcon />
+          </div>
+          <p className='text-gray-700'>찾는 음식이 없나요?</p>
+        </div>
+
+        <Link
+          to='/meal/custom'
+          className='bg-secondary rounded-full text-white font-bold text-sm px-4 py-2'
+        >
+          직접 등록
+        </Link>
+      </div>
+
+      <div className='flex flex-col min-h-[calc(100vh-266px)]'>
+        <div className='flex-1 px-[20px]'>
+          {foodItems.length > 0 ? (
+            <FoodList
+              variant='select'
+              selectedIds={selectedIds}
+              onToggleSelect={handleToggleSelect}
+              items={foodItems}
+            />
+          ) : (
+            <EmptyState className='min-h-[calc(100vh-266px)]'>등록한 음식이 없어요</EmptyState>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yum-yum/src/pages/meal/page/CustomEntryForm.jsx
+++ b/yum-yum/src/pages/meal/page/CustomEntryForm.jsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+// 컴포넌트
+import MealHeader from '../component/MealHeader';
+import BasicButton from '@/components/button/BasicButton';
+import Input from '@/components/common/Input';
+import NutritionSection from '../component/NutritionSection';
+
+export default function CustomEntryForm() {
+  const navigate = useNavigate();
+  const [foodName, setFoodName] = useState('');
+  const [foodSize, setFoodSize] = useState('');
+  const [foodUnit, setFoodUnit] = useState('g');
+
+  // 등록 완료 버튼
+  const handleSubmitRegister = () => {
+    navigate('/');
+  };
+  return (
+    <div>
+      <MealHeader isRight={true}>직접 등록</MealHeader>
+
+      <div className='flex flex-col min-h-[calc(100vh-60px)]'>
+        <div className='flex-1 flex flex-col gap-[24px] px-[20px]'>
+          {/* 음식명 */}
+          <div className='flex flex-col gap-[8px]'>
+            <label className='font-bold' htmlFor='foodName'>
+              음식명 <strong className='font-extrabold text-secondary'>*</strong>
+            </label>
+            <Input
+              id='foodName'
+              placeholder='음식명 (최대 20자)'
+              maxLength={20}
+              value={foodName}
+              onChange={(e) => setFoodName(e.target.value)}
+            />
+          </div>
+
+          {/* 내용량 */}
+          <div className='flex flex-col gap-[8px]'>
+            <label className='font-bold' htmlFor='foodSize'>
+              내용량<span className='text-xs text-gray-500'>(1회 제공량 기준)</span>{' '}
+              <strong className='font-extrabold text-secondary'>*</strong>
+            </label>
+
+            <div className='flex gap-2'>
+              <Input
+                id='foodSize'
+                maxLength={8}
+                value={foodSize}
+                onChange={(e) => setFoodSize(e.target.value)}
+              />
+
+              <select
+                value={foodUnit}
+                onChange={(e) => setFoodUnit(e.target.value)}
+                className='w-full max-w-[226px] h-[48px] px-4 border border-[var(--color-gray-300)] rounded-lg transition-colors outline-none'
+              >
+                <option value='g'>g</option>
+                <option value='ml'>ml</option>
+              </select>
+            </div>
+          </div>
+
+          {/* 영양정보 */}
+          <NutritionSection />
+        </div>
+
+        <div className='sticky bottom-0 z-30 w-full max-w-[500px] p-[20px] bg-white'>
+          <BasicButton size='full' onClick={handleSubmitRegister}>
+            등록 완료
+          </BasicButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yum-yum/src/pages/meal/page/FrequentlyEatenFood.jsx
+++ b/yum-yum/src/pages/meal/page/FrequentlyEatenFood.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+// 컴포넌트
+import EmptyState from '@/components/EmptyState';
+import FoodList from '../component/FoodList';
+
+const foodItems = [
+  {
+    id: '1',
+    foodName: '두유',
+    makerName: '',
+    foodWeight: '200',
+    foodCal: '110',
+  },
+  {
+    id: '2',
+    foodName: '약콩두유',
+    makerName: '대학두유',
+    foodWeight: '190',
+    foodCal: '100',
+  },
+  {
+    id: '3',
+    foodName: '약콩두유',
+    makerName: '대학두유',
+    foodWeight: '190',
+    foodCal: '100',
+  },
+];
+
+export default function FrequentlyEatenFood() {
+  const [selectedIds, setSelectedIds] = useState([]);
+  const handleToggleSelect = (id) => {
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+    console.log(id);
+  };
+
+  return (
+    <div>
+      <div className='flex flex-col min-h-[calc(100vh-206px)]'>
+        <div className='flex-1 px-[20px]'>
+          {foodItems.length > 0 ? (
+            <FoodList
+              variant='select'
+              selectedIds={selectedIds}
+              onToggleSelect={handleToggleSelect}
+              items={foodItems}
+            />
+          ) : (
+            <EmptyState className='min-h-[calc(100vh-266px)]'>자주 먹은 음식이 없어요</EmptyState>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yum-yum/src/pages/meal/page/TotalMeal.jsx
+++ b/yum-yum/src/pages/meal/page/TotalMeal.jsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+// 컴포넌트
+import MealHeader from '../component/MealHeader';
+import FoodList from '../component/FoodList';
+import BasicButton from '@/components/button/BasicButton';
+
+const foodItems = [
+  {
+    id: '1',
+    foodName: '두유',
+    makerName: '',
+    foodWeight: '200',
+    foodCal: '110',
+  },
+  {
+    id: '2',
+    foodName: '약콩두유',
+    makerName: '대학두유',
+    foodWeight: '190',
+    foodCal: '100',
+  },
+  {
+    id: '3',
+    foodName: '약콩두유',
+    makerName: '대학두유',
+    foodWeight: '190',
+    foodCal: '100',
+  },
+];
+
+export default function TotalMeal() {
+  const navigate = useNavigate();
+  const [foods, setFoods] = useState(foodItems);
+  const foodCount = foods.length;
+
+  const date = new Date();
+
+  // - 버튼
+  const handleDelete = (id) => {
+    setFoods((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  // 음식 추가 버튼
+  const handleAddFood = () => {
+    navigate('/meal');
+  };
+
+  // 기록 완료 버튼
+  const handleSubmitRecord = () => {
+    navigate('/');
+  };
+
+  return (
+    <div>
+      {/* 헤더 */}
+      <MealHeader>{date.toLocaleDateString()} 아침</MealHeader>
+
+      <div className='flex flex-col min-h-[calc(100vh-60px)]'>
+        <div className='flex-1 px-[20px]'>
+          {/* 총 열량 */}
+          <div className='pt-[20px] pb-[36px]'>
+            <div className='flex flex-col gap-[28px] px-[32px] py-[28px] bg-secondary-light rounded-2xl'>
+              <div className='flex justify-between text-lg font-bold'>
+                <h3>총 열량</h3>
+                <p>210kcal</p>
+              </div>
+
+              <div className=''>그래프 영역</div>
+            </div>
+          </div>
+
+          {/* 추가한 음식 */}
+          <div className='pt-[36px] border-t-[12px] border-gray-50 '>
+            <h3 className='text-lg font-bold'>
+              추가한 음식 <strong className='text-primary font-extrabold'>{foodCount}</strong>
+            </h3>
+            <FoodList variant='delete' onDelete={handleDelete} items={foods} />
+          </div>
+        </div>
+
+        {/* 버튼 */}
+        <div className='sticky bottom-0 z-30 flex gap-[12px] w-full max-w-[500px] p-[20px] bg-white'>
+          <BasicButton size='full' variant='line' onClick={handleAddFood}>
+            음식 추가
+          </BasicButton>
+          <BasicButton size='full' onClick={handleSubmitRecord}>
+            기록 완료
+          </BasicButton>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 작업 개요
- 식단 기록 페이지 UI
- 헤더, 탭, 음식 리스트 컴포넌트 추가
- 자주 먹은 음식, 직접 등록, 직접 등록, 식단 기록 상세 페이지 추가

## 🔨 작업 내용
- 헤더: 페이지에 따라 타입 변경, 뒤로가기 버튼
- 음식 리스트 컴포넌트: 페이지에 따라 아이콘 변경, +버튼 토글, 리스트 클릭 시 음식 상세 정보 모달 호출

## ✅ 테스트 방법
- 직접 테스트하는 방법
- 예상 동작

## 📎 관련 이슈

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)