### PR TITLE
[feat] 메인 페이지 UI 배치

### DIFF
--- a/yum-yum/src/components/button/BasicButton.jsx
+++ b/yum-yum/src/components/button/BasicButton.jsx
@@ -16,6 +16,7 @@ export default function BasicButton({
       disabled={disabled}
       // h-12 px-5 bg-emerald-500 rounded-lg inline-flex justify-center items-center gap-2 overflow-hidden
       className={clsx('rounded-lg flex justify-center items-center', {
+        'px-2 h-8': size === 'xs',
         'px-2 h-12': size === 'sm',
         'px-5 h-12': size === 'md',
         'px-8 h-12': size === 'lg',

--- a/yum-yum/src/pages/home/HomePage.jsx
+++ b/yum-yum/src/pages/home/HomePage.jsx
@@ -1,13 +1,21 @@
 /**
  TODO: 화면 우선 제작
  */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import DateHeader from '@/components/common/DateHeader';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { registerLocale, setDefaultLocale } from 'react-datepicker';
 import { ko } from 'date-fns/locale';
-import OnBoarding from '../../components/common/OnBoarding';
+import OnBoarding from '@/components/common/OnBoarding';
+import BaseCard from './card/BaseCard';
+import MealCard from './card/nutrition/MealCard';
+import WeightCard from './card/weight/WeightCard';
+import CalorieCard from './card/calorie/CalorieCard';
+import CalorieChart from './card/calorie/CalorieChart';
+import CalorieHeader from './card/calorie/CalorieHeader';
+import CalorieMessage from './card/calorie/CalorieMessage';
+import CalorieNutrition from './card/calorie/CalorieNutrition';
 
 registerLocale('ko', ko);
 
@@ -16,10 +24,14 @@ export default function HomePage() {
   const [calendarOepn, setCalendarOpen] = useState(false);
   const [onboardOpen, setOnboardOpen] = useState(false);
 
+  useEffect(() => {
+    //
+  }, []);
+
   return (
-    <div className='flex flex-row gap-8 justify-center item-center bg-primary-light w-full h-full min-h-screen'>
+    <div className='flex flex-col gap-8 justify-start item-center bg-primary-light w-full h-full min-h-screen'>
       {/* 최상단 날짜 */}
-      <div className=' w-full h-full'>
+      <div className='w-full h-full'>
         <DateHeader
           date={date}
           onCalendarClick={() => {
@@ -49,11 +61,63 @@ export default function HomePage() {
       </div>
       {/* OnBoarding 컴포넌트 */}
       <OnBoarding isOpen={onboardOpen} onClose={() => setOnboardOpen(false)} />
-      {/* 실시간 칼로리 카드 */}
 
-      {/* 체중 정보 카드 */}
+      {/* 카드 모음 */}
+      <div className='w-full h-full px-4 flex flex-col justify-start gap-8 mb-8'>
+        {/* 실시간 칼로리 카드 */}
+        <BaseCard>
+          <CalorieCard>
+            {/* 헤더 */}
+            <CalorieHeader />
+            {/* 남은 칼로리 */}
+            <CalorieMessage currentCalories={1900} totalCalories={1800} />
+            {/* 차트 */}
+            <CalorieChart currentCalories={1900} totalCalories={1800} />
+            {/* 영양소 정보 */}
+            <CalorieNutrition carbs={27.8} protein={5.7} fat={7.2} />
+          </CalorieCard>
+        </BaseCard>
 
-      {/* 실시간 식단 표 */}
+        {/* 체중 정보 카드 */}
+        <BaseCard>
+          <WeightCard
+            currentWeight={68}
+            targetWeight={62}
+            onWeightInput={() => {
+              // 체중 입력 모달 열기 등의 로직
+              console.log('체중 입력 버튼 클릭');
+            }}
+          />
+        </BaseCard>
+
+        {/* 실시간 식단 표 */}
+        <BaseCard>
+          <div className='p-6 sm:p-8'>
+            <MealCard
+              meals={{
+                _id: 1,
+                breakfast: {
+                  calories: 280,
+                  foods: '쌀밥, 미역국, 김치, 소고기장조림, 쌀밥, 미역국, 김치, 소고기장조림',
+                },
+                lunch: { calories: 0, foods: null },
+                dinner: { calories: 0, foods: null },
+                snack: { calories: 0, foods: null },
+              }}
+              water={{ current: 1.2, goal: 2.0 }}
+              onAddMeal={(id, mealType) => {
+                console.log(`${id}의 ${mealType} 식사 추가`);
+              }}
+              onUpdateMeal={(id, mealType) => {
+                console.log(`${id}의 ${mealType} 식사 편집`);
+              }}
+              onAddWater={() => {
+                console.log('물 추가');
+              }}
+            />
+          </div>
+        </BaseCard>
+      </div>
     </div>
   );
 }

--- a/yum-yum/src/pages/home/card/BaseCard.jsx
+++ b/yum-yum/src/pages/home/card/BaseCard.jsx
@@ -1,0 +1,13 @@
+/**
+ * 전체 카드 컨테이너
+ * 카드 스타일링 (border-radius, shadow 등)
+ */
+import React from 'react';
+
+export default function BaseCard({ children }) {
+  return (
+    <div className='bg-white rounded-[20px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] '>
+      {children}
+    </div>
+  );
+}

--- a/yum-yum/src/pages/home/card/calorie/CalorieCard.jsx
+++ b/yum-yum/src/pages/home/card/calorie/CalorieCard.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CalorieCard = ({ children }) => {
+  return <div className='p-6'>{children}</div>;
+};
+
+export default CalorieCard;

--- a/yum-yum/src/pages/home/card/calorie/CalorieChart.jsx
+++ b/yum-yum/src/pages/home/card/calorie/CalorieChart.jsx
@@ -33,7 +33,7 @@ export default function CalorieChart({ currentCalories = 1800, totalCalories = 1
       <div className='relative w-80 h-80'>
         {' '}
         {/* 크기 증가 */}
-        <PieChart width={320} height={320}>
+        <PieChart width={320} height={280}>
           {' '}
           {/* PieChart 크기도 증가 */}
           <Pie

--- a/yum-yum/src/pages/home/card/calorie/CalorieChart.jsx
+++ b/yum-yum/src/pages/home/card/calorie/CalorieChart.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { PieChart, Pie, Legend, Tooltip } from 'recharts';
+import clsx from 'clsx';
+
+export default function CalorieChart({ currentCalories = 1800, totalCalories = 1800 }) {
+  // 목표 달성 여부에 따른 색상 결정
+  const isOverTarget = currentCalories > totalCalories;
+  const currentColor = isOverTarget ? '#FF5094' : '#12B76A'; // 초과시 빨강, 미달시 초록
+  const remainingColor = '#EAECF0'; // 남은 부분은 회색
+
+  const calorieRatioData = [
+    {
+      name: '총 섭취량',
+      value: Math.min(currentCalories, totalCalories), // 목표치를 넘으면 목표치까지만
+      fill: currentColor,
+    },
+    {
+      name: '남은 칼로리',
+      value: Math.max(totalCalories - currentCalories, 0), // 음수가 되지 않도록
+      fill: remainingColor,
+    },
+  ];
+
+  // 목표 초과시
+  const overTargetData = [
+    { name: '목표 칼로리', value: totalCalories, fill: '#12B76A' },
+    { name: '초과 칼로리', value: currentCalories - totalCalories, fill: '#FF5094' },
+  ];
+  const chartData = isOverTarget ? overTargetData : calorieRatioData;
+
+  return (
+    <div className='flex justify-center mb-12'>
+      <div className='relative w-80 h-80'>
+        {' '}
+        {/* 크기 증가 */}
+        <PieChart width={320} height={320}>
+          {' '}
+          {/* PieChart 크기도 증가 */}
+          <Pie
+            data={chartData}
+            dataKey={'value'}
+            nameKey={'name'}
+            innerRadius={90}
+            outerRadius={120}
+            cx={160}
+            cy={150}
+            startAngle={90}
+            endAngle={-270}
+          />
+        </PieChart>
+        <div className='absolute inset-0 flex flex-col items-center justify-center'>
+          <div className='text-center mb-1'>
+            <span
+              className={clsx(
+                'text-4xl font-extrabold',
+                { 'text-primary': currentCalories <= totalCalories },
+                { 'text-secondary-dark': currentCalories > totalCalories },
+              )}
+            >
+              {currentCalories}
+            </span>
+            <span className='text-gray-500 text-xl font-extrabold'>/{totalCalories}</span>
+          </div>
+          <div className='text-gray-500 text-xl font-extrabold mt-1'>kcal</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yum-yum/src/pages/home/card/calorie/CalorieChart.jsx
+++ b/yum-yum/src/pages/home/card/calorie/CalorieChart.jsx
@@ -27,7 +27,8 @@ export default function CalorieChart({ currentCalories = 1800, totalCalories = 1
     { name: '초과 칼로리', value: currentCalories - totalCalories, fill: '#FF5094' },
   ];
   const chartData = isOverTarget ? overTargetData : calorieRatioData;
-
+  const startAngle = isOverTarget ? -270 : 90;
+  const endAngle = isOverTarget ? 90 : -270;
   return (
     <div className='flex justify-center mb-12'>
       <div className='relative w-80 h-80'>
@@ -44,8 +45,8 @@ export default function CalorieChart({ currentCalories = 1800, totalCalories = 1
             outerRadius={120}
             cx={160}
             cy={150}
-            startAngle={90}
-            endAngle={-270}
+            startAngle={startAngle}
+            endAngle={endAngle}
           />
         </PieChart>
         <div className='absolute inset-0 flex flex-col items-center justify-center'>

--- a/yum-yum/src/pages/home/card/calorie/CalorieHeader.jsx
+++ b/yum-yum/src/pages/home/card/calorie/CalorieHeader.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import BasicButton from '@/components/button/BasicButton';
+
+export default function CalorieHeader() {
+  return (
+    <div className='flex justify-between items-center mb-6 sm:mb-8'>
+      <h2 className='text-gray-800 text-xl sm:text-2xl font-extrabold'>오늘의 칼로리</h2>
+      <BasicButton size='xs' variant='line' onClick={() => {}}>
+        전체보기
+      </BasicButton>
+    </div>
+  );
+}

--- a/yum-yum/src/pages/home/card/calorie/CalorieHeader.jsx
+++ b/yum-yum/src/pages/home/card/calorie/CalorieHeader.jsx
@@ -3,8 +3,8 @@ import BasicButton from '@/components/button/BasicButton';
 
 export default function CalorieHeader() {
   return (
-    <div className='flex justify-between items-center mb-6 sm:mb-8'>
-      <h2 className='text-gray-800 text-xl sm:text-2xl font-extrabold'>오늘의 칼로리</h2>
+    <div className='flex justify-between items-center mb-6 '>
+      <h2 className='text-gray-800 text-2xl font-extrabold'>오늘의 칼로리</h2>
       <BasicButton size='xs' variant='line' onClick={() => {}}>
         전체보기
       </BasicButton>

--- a/yum-yum/src/pages/home/card/calorie/CalorieMessage.jsx
+++ b/yum-yum/src/pages/home/card/calorie/CalorieMessage.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import clsx from 'clsx';
+import { motiveMessage } from '@/data/motivateMessage';
+
+export default function CalorieMessage({ currentCalories = 1060, totalCalories = 1800 }) {
+  const remainingCalories = currentCalories - totalCalories;
+  const getCalorieMessage = (currentCalories, remainingCalories) => {
+    // 아직 섭취한 칼로리가 없는 경우
+    if (currentCalories === 0) {
+      return motiveMessage.empty;
+    }
+    // 목표 칼로리 초과
+    if (remainingCalories > 0) {
+      return motiveMessage.overgoal;
+    }
+    // 목표 칼로리 미달
+    if (remainingCalories < 0) {
+      return motiveMessage.undergoal;
+    }
+    // 목표 칼로리 정확히 달성
+    return motiveMessage.donegoal;
+  };
+  const message = getCalorieMessage(currentCalories, remainingCalories);
+
+  return (
+    <div className='text-center mb-4 sm:mb-6'>
+      <span
+        className={clsx(
+          { 'text-gray-800 text-2xl font-extrabold': currentCalories !== totalCalories },
+          {
+            'text-gray-800 text-xl font-bold':
+              currentCalories === totalCalories || currentCalories === 0,
+          },
+        )}
+      >
+        {message}
+      </span>
+      {currentCalories !== 0 && currentCalories !== totalCalories && (
+        <>
+          <span
+            className={clsx(
+              'text-3xl font-extrabold',
+              { 'text-primary': currentCalories <= totalCalories },
+              { 'text-secondary-dark': currentCalories > totalCalories },
+            )}
+          >
+            {' '}
+            {Math.abs(remainingCalories)}{' '}
+          </span>
+          <span className='text-gray-800 text-lg sm:text-2xl font-extrabold'>kcal</span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/yum-yum/src/pages/home/card/calorie/CalorieMessage.jsx
+++ b/yum-yum/src/pages/home/card/calorie/CalorieMessage.jsx
@@ -23,7 +23,7 @@ export default function CalorieMessage({ currentCalories = 1060, totalCalories =
   const message = getCalorieMessage(currentCalories, remainingCalories);
 
   return (
-    <div className='text-center mb-4 sm:mb-6'>
+    <div className='text-center mb-4 '>
       <span
         className={clsx(
           { 'text-gray-800 text-2xl font-extrabold': currentCalories !== totalCalories },
@@ -47,7 +47,7 @@ export default function CalorieMessage({ currentCalories = 1060, totalCalories =
             {' '}
             {Math.abs(remainingCalories)}{' '}
           </span>
-          <span className='text-gray-800 text-lg sm:text-2xl font-extrabold'>kcal</span>
+          <span className='text-gray-800 text-2xl font-extrabold'>kcal</span>
         </>
       )}
     </div>

--- a/yum-yum/src/pages/home/card/calorie/CalorieNutrition.jsx
+++ b/yum-yum/src/pages/home/card/calorie/CalorieNutrition.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function CalorieNutrition({ carbs = 27.8, protein = 5.7, fat = 7.2 }) {
+  return (
+    <div className='grid grid-cols-3 gap-4 text-center'>
+      <div>
+        <div className='text-gray-800 text-sm font-normal'>탄수화물</div>
+        <div className='text-gray-800 text-sm font-bold'>{carbs}g</div>
+      </div>
+      <div>
+        <div className='text-gray-800 text-sm font-normal'>단백질</div>
+        <div className='text-gray-800 text-sm font-bold'>{protein}g</div>
+      </div>
+      <div>
+        <div className='text-gray-800 text-sm font-normal'>지방</div>
+        <div className='text-gray-800 text-sm font-bold'>{fat}g</div>
+      </div>
+    </div>
+  );
+}

--- a/yum-yum/src/pages/home/card/calorie/CalorieNutrition.jsx
+++ b/yum-yum/src/pages/home/card/calorie/CalorieNutrition.jsx
@@ -2,17 +2,17 @@ import React from 'react';
 
 export default function CalorieNutrition({ carbs = 27.8, protein = 5.7, fat = 7.2 }) {
   return (
-    <div className='grid grid-cols-3 gap-4 text-center'>
-      <div>
-        <div className='text-gray-800 text-sm font-normal'>탄수화물</div>
+    <div className='flex flex-row gap-8 item-center justify-center mt-[-30px] mb-4'>
+      <div className='flex gap-1 item-center justify-center'>
+        <div className='text-gray-800 text-sm font-normal'>탄</div>
         <div className='text-gray-800 text-sm font-bold'>{carbs}g</div>
       </div>
-      <div>
-        <div className='text-gray-800 text-sm font-normal'>단백질</div>
+      <div className='flex gap-1 item-center justify-center'>
+        <div className='text-gray-800 text-sm font-normal'>단</div>
         <div className='text-gray-800 text-sm font-bold'>{protein}g</div>
       </div>
-      <div>
-        <div className='text-gray-800 text-sm font-normal'>지방</div>
+      <div className='flex gap-1 item-center justify-center'>
+        <div className='text-gray-800 text-sm font-normal'>지</div>
         <div className='text-gray-800 text-sm font-bold'>{fat}g</div>
       </div>
     </div>

--- a/yum-yum/src/pages/home/card/nutrition/CheckButton.jsx
+++ b/yum-yum/src/pages/home/card/nutrition/CheckButton.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export default function CheckButton({ hasData = false, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        'w-7 h-7 rounded-full flex items-center justify-center transition-colors hover:scale-105',
+        hasData ? 'bg-secondary hover:bg-secondary-hover' : 'bg-primary hover:bg-primary-hover',
+      )}
+    >
+      {hasData ? (
+        // 편집 아이콘 (빨간색)
+        <svg className='w-4 h-4 text-white' fill='currentColor' viewBox='0 0 20 20'>
+          <path d='M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.828-2.828z' />
+        </svg>
+      ) : (
+        // 추가 아이콘 (초록색)
+        <svg className='w-4 h-4 text-white' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+          <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M12 4v16m8-8H4' />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/yum-yum/src/pages/home/card/nutrition/CheckButton.jsx
+++ b/yum-yum/src/pages/home/card/nutrition/CheckButton.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
+import IconMode from '@/assets/icons/icon-mode.svg?react';
+import IconPlus from '@/assets/icons/icon-plus.svg?react';
 
 export default function CheckButton({ hasData = false, onClick }) {
   return (
@@ -12,14 +14,10 @@ export default function CheckButton({ hasData = false, onClick }) {
     >
       {hasData ? (
         // 편집 아이콘 (빨간색)
-        <svg className='w-4 h-4 text-white' fill='currentColor' viewBox='0 0 20 20'>
-          <path d='M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.828-2.828z' />
-        </svg>
+        <IconMode />
       ) : (
         // 추가 아이콘 (초록색)
-        <svg className='w-4 h-4 text-white' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-          <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M12 4v16m8-8H4' />
-        </svg>
+        <IconPlus fill={'#12b76a'} />
       )}
     </button>
   );

--- a/yum-yum/src/pages/home/card/nutrition/MealCard.jsx
+++ b/yum-yum/src/pages/home/card/nutrition/MealCard.jsx
@@ -34,15 +34,13 @@ const MealCard = ({
           <div className='flex justify-between items-start mb-3'>
             <div className='flex-1'>
               <div className='flex items-center gap-2 mb-2'>
-                <h3 className='text-slate-800 text-xl sm:text-2xl font-extrabold'>
-                  {section.title}
-                </h3>
+                <h3 className='text-gray-800 text-xl font-extrabold'>{section.title}</h3>
                 {section.data.calories > 0 && (
                   <div className='flex items-baseline gap-2'>
-                    <span className='text-slate-800 text-2xl sm:text-3xl font-extrabold'>
+                    <span className='text-gray-800 text-2xl font-extrabold'>
                       {section.data.calories}
                     </span>
-                    <span className='text-pink-500 text-base sm:text-lg font-bold'>kcal</span>
+                    <span className='text-pink-500 text-base font-bold'>kcal</span>
                   </div>
                 )}
               </div>
@@ -73,10 +71,12 @@ const MealCard = ({
       <div className='border-b border-gray-300 my-4'></div>
 
       <div className='flex justify-between items-center'>
-        <div className='flex items-baseline gap-2'>
-          <h3 className='text-slate-800 text-xl sm:text-2xl font-extrabold'>물</h3>
-          <span className='text-pink-500 text-2xl sm:text-3xl font-extrabold'>{water.current}</span>
-          <span className='text-slate-800 text-base sm:text-lg font-bold'>/{water.goal}L</span>
+        <div className='flex items-center gap-2'>
+          <h3 className='text-gray-800 text-xl font-extrabold'>물</h3>
+          <div className='flex items-baseline gap-2'>
+            <span className='text-pink-500 text-2xl font-extrabold'>{water.current}</span>
+            <span className='text-gray-800 text-base font-bold'>/{water.goal}L</span>
+          </div>
         </div>
 
         <CheckButton hasData={false} onClick={() => onAddWater?.()} />

--- a/yum-yum/src/pages/home/card/nutrition/MealCard.jsx
+++ b/yum-yum/src/pages/home/card/nutrition/MealCard.jsx
@@ -1,0 +1,88 @@
+// 메인 식단(아침,점심,저녁) 기록 카드
+import React from 'react';
+import clsx from 'clsx';
+import CheckButton from './CheckButton';
+
+const MealCard = ({
+  meals = {
+    _id: 1,
+    breakfast: {
+      calories: 280,
+      foods: '쌀밥, 미역국, 김치, 소고기장조림, 보쌈, 쌀밥, 미역국, 김치, 소고...',
+    },
+    lunch: { calories: 0, foods: null },
+    dinner: { calories: 0, foods: null },
+    snack: { calories: 0, foods: null },
+  },
+  water = { current: 1.2, goal: 2.0 },
+  onAddMeal,
+  onUpdateMeal,
+  onAddWater,
+}) => {
+  const mealSections = [
+    { key: 'breakfast', title: '아침', data: meals.breakfast },
+    { key: 'lunch', title: '점심', data: meals.lunch },
+    { key: 'dinner', title: '저녁', data: meals.dinner },
+    { key: 'snack', title: '기타', data: meals.snack },
+  ];
+
+  return (
+    <div>
+      {/* 식사 섹션들 */}
+      {mealSections.map((section, index) => (
+        <div key={section.key}>
+          <div className='flex justify-between items-start mb-3'>
+            <div className='flex-1'>
+              <div className='flex items-center gap-2 mb-2'>
+                <h3 className='text-slate-800 text-xl sm:text-2xl font-extrabold'>
+                  {section.title}
+                </h3>
+                {section.data.calories > 0 && (
+                  <div className='flex items-baseline gap-2'>
+                    <span className='text-slate-800 text-2xl sm:text-3xl font-extrabold'>
+                      {section.data.calories}
+                    </span>
+                    <span className='text-pink-500 text-base sm:text-lg font-bold'>kcal</span>
+                  </div>
+                )}
+              </div>
+
+              <p className='text-gray-500 text-sm leading-relaxed line-clamp-1'>
+                {section.data.foods || '아직 기록이 없습니다'}
+              </p>
+            </div>
+
+            <CheckButton
+              hasData={section.data.calories > 0}
+              onClick={() => {
+                if (section.data.calories > 0) {
+                  onUpdateMeal(meals._id, section.key);
+                } else {
+                  onAddMeal(meals._id, section.key);
+                }
+              }}
+            />
+          </div>
+
+          {/* 구분선 (마지막 섹션 제외) */}
+          {index < mealSections.length - 1 && <div className='border-b border-gray-300 my-4'></div>}
+        </div>
+      ))}
+
+      {/* 물 섭취 섹션 */}
+      <div className='border-b border-gray-300 my-4'></div>
+
+      <div className='flex justify-between items-center'>
+        <div className='flex items-baseline gap-2'>
+          <h3 className='text-slate-800 text-xl sm:text-2xl font-extrabold'>물</h3>
+          <span className='text-pink-500 text-2xl sm:text-3xl font-extrabold'>{water.current}</span>
+          <span className='text-slate-800 text-base sm:text-lg font-bold'>/{water.goal}L</span>
+        </div>
+
+        <CheckButton hasData={false} onClick={() => onAddWater?.()} />
+      </div>
+    </div>
+  );
+};
+
+export default MealCard;

--- a/yum-yum/src/pages/home/card/weight/WeightCard.jsx
+++ b/yum-yum/src/pages/home/card/weight/WeightCard.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import BasicButton from '@/components/button/BasicButton';
+
+export default function WeightCard({ currentWeight = 68, targetWeight = 62, onWeightInput }) {
+  const remainingWegiht = currentWeight - targetWeight;
+  const isGoalReached = remainingWegiht <= 0;
+
+  return (
+    <div className='p-6 sm:p-8'>
+      {/* 헤더 영역 */}
+      <div className='flex justify-between items-start mb-2'>
+        <div className='flex flex-col gap-6'>
+          <h2 className='text-gray-800 text-2xl font-extrabold'>체중</h2>
+          {/* 체중 정보 */}
+          <div className='space-y-3 mb-8'>
+            <div className='flex justify-between items-center'>
+              <span className='text-gray-800 text-mb font-bold'>현재 체중</span>
+              <span className='text-gray-800 text-mb font-bold'>{currentWeight}kg</span>
+            </div>
+
+            <div className='flex justify-between items-center'>
+              <span className='text-gray-800 text-mb font-bold'>목표 체중</span>
+              <span className='text-gray-800 text-mb font-bold'>{targetWeight}kg</span>
+            </div>
+          </div>
+        </div>
+
+        {/* 목표까지 남은 무게 박스 */}
+        <div
+          className={`rounded-[20px] p-7  text-center flex-shrink-0 ${
+            isGoalReached ? 'bg-blue-100' : 'bg-pink-100'
+          }`}
+        >
+          <div className='text-gray-800 text-mb  font-bold leading-tight'>
+            {isGoalReached ? '목표 달성!' : '목표 무게까지'}
+          </div>
+          <div
+            className={`text-3xl font-bold leading-tight ${
+              isGoalReached ? 'text-primary' : 'text-secondary'
+            }`}
+          >
+            {isGoalReached ? '완료!' : `-${remainingWegiht}kg!`}
+          </div>
+        </div>
+      </div>
+
+      {/* 체중 입력 버튼 */}
+      <BasicButton variant='line' size='full' onClick={onWeightInput}>
+        체중 입력
+      </BasicButton>
+    </div>
+  );
+}

--- a/yum-yum/src/pages/home/card/weight/WeightCard.jsx
+++ b/yum-yum/src/pages/home/card/weight/WeightCard.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import BasicButton from '@/components/button/BasicButton';
 
 export default function WeightCard({ currentWeight = 68, targetWeight = 62, onWeightInput }) {
-  const remainingWegiht = currentWeight - targetWeight;
-  const isGoalReached = remainingWegiht <= 0;
+  const remainingWegiht = targetWeight - currentWeight;
+  const isGoalReached = remainingWegiht == 0;
 
   return (
     <div className='p-6 sm:p-8'>
@@ -27,11 +27,11 @@ export default function WeightCard({ currentWeight = 68, targetWeight = 62, onWe
 
         {/* 목표까지 남은 무게 박스 */}
         <div
-          className={`rounded-[20px] p-7  text-center flex-shrink-0 ${
+          className={`rounded-[20px] p-6  text-center flex-shrink-0 ${
             isGoalReached ? 'bg-blue-100' : 'bg-pink-100'
           }`}
         >
-          <div className='text-gray-800 text-mb  font-bold leading-tight'>
+          <div className='text-gray-800 text-mb  font-bold leading-tight mb-3'>
             {isGoalReached ? '목표 달성!' : '목표 무게까지'}
           </div>
           <div
@@ -39,7 +39,7 @@ export default function WeightCard({ currentWeight = 68, targetWeight = 62, onWe
               isGoalReached ? 'text-primary' : 'text-secondary'
             }`}
           >
-            {isGoalReached ? '완료!' : `-${remainingWegiht}kg!`}
+            {isGoalReached ? '완료!' : `${remainingWegiht}kg!`}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 📝 작업 개요
- 메인 페이지의 UI 배치

## 🔨 작업 내용
- 공용 버튼(BasicButton) 사이즈 1개 추가(xs) 
- pages 디렉토리의 home에 카드 추가

## ✅ 테스트 방법
- localhost:5173 접속
<img width="506" height="862" alt="스크린샷 2025-09-08 오후 5 47 00" src="https://github.com/user-attachments/assets/eb45360c-4b60-488e-ab3c-871fe30ba28a" />
<img width="505" height="863" alt="스크린샷 2025-09-08 오후 5 47 10" src="https://github.com/user-attachments/assets/a7680ba5-3679-4163-8bda-50151bce2d0b" />


## 📎 관련 이슈
- Close #이슈번호(선택)