### PR TITLE
[fix] 모달 컴포넌트 닫기 버튼 너비,높이 설정

### DIFF
--- a/yum-yum/src/components/Modal.jsx
+++ b/yum-yum/src/components/Modal.jsx
@@ -35,7 +35,7 @@ export default function Modal({
           <h2 className='font-bold text-lg'>{title}</h2>
 
           {showClose && (
-            <button onClick={onCloseModal} className='flex items-center justify-center'>
+            <button onClick={onCloseModal} className='flex items-center justify-center w-6 h-6'>
               <CloseIcon />
             </button>
           )}


### PR DESCRIPTION
## 📝 작업 개요
- 모달 컴포넌트 닫기 버튼 너비,높이 설정이 안되어있어 닫기 버튼이 안보이는 현상 발생

## 🔨 작업 내용
- 닫기 버튼 너비, 높이 설정

## ✅ 테스트 방법
- 아직 ㅊㅔ중 입력 버튼 커밋을 하지 않아 테스트에 어려움이 있을 수 있습니다.
<img width="446" height="311" alt="스크린샷 2025-09-09 오후 2 25 23" src="https://github.com/user-attachments/assets/bf10feb7-87e0-461b-9457-79419f6ab0b9" />


## 📎 관련 이슈
- 