### PR TITLE
[feat] 체중 기록 모달, 네비게이션 경로 추가

### DIFF
--- a/yum-yum/src/App.jsx
+++ b/yum-yum/src/App.jsx
@@ -32,6 +32,7 @@ const router = createBrowserRouter([
         children: [
           { index: true, element: <HomePage /> },
           { path: 'meal', element: <MealPage /> },
+          { path: 'meal/:type', element: <MealPage /> }, // 아침, 점심, 저녁, 기타 타입
           { path: 'meal/custom', element: <CustomEntryForm /> },
           // { path: 'meal/search', element: <SearchList /> },
           { path: 'meal/total', element: <TotalMeal /> },

--- a/yum-yum/src/components/modal/MenuModal.jsx
+++ b/yum-yum/src/components/modal/MenuModal.jsx
@@ -1,5 +1,6 @@
 // 식사 type 선택 후, 값 어떻게 넘겨야하는지?
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const menuItems = [
   { id: '1', name: '아침' },
@@ -10,10 +11,12 @@ const menuItems = [
 
 export default function MenuModal({ isOpen, onClose }) {
   if (!isOpen) return null;
+  const navigate = useNavigate();
 
   const menuSelected = (item) => {
     // 선택 값 => 식단 입력 이동
-
+    // console.log('item: ', item.name);
+    navigate(`/meal/${item.name}`);
     // 창 닫기
     onClose;
   };

--- a/yum-yum/src/data/mockUser.js
+++ b/yum-yum/src/data/mockUser.js
@@ -1,5 +1,5 @@
 // 테스트용 유저데이터
-const mockUser = {
+export const mockUser = {
   _id: '1',
   userId: 'test@gmail.com',
   name: '김철수',

--- a/yum-yum/src/hooks/useWeight.js
+++ b/yum-yum/src/hooks/useWeight.js
@@ -1,0 +1,59 @@
+// 몸무게 입력 커스텀 훅
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { saveWeight } from '@/services/weightApi';
+import { getUserData } from '@/services/userApi';
+
+export const useWeight = (userId) => {
+  const queryClient = useQueryClient();
+
+  // 사용자 데이터 불러오기
+  const userData = useQuery({
+    queryKey: ['user', userId],
+    queryFn: () => getUserData(userId),
+    select: (response) => response.data,
+    enabled: !!userId,
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 10 * 60 * 1000,
+    retry: 2,
+  });
+
+  // 체중 수정(저장)하기
+  const saveWeightMutation = useMutation({
+    mutationFn: ({ weight }) => saveWeight({ userId, weight }),
+    onSuccess: (response) => {
+      if (response.success) {
+        // 사용자 데이터 쿼리 무효화하여 새로고침
+        queryClient.invalidateQueries({
+          queryKey: ['user', userId],
+        });
+        // 옵티미스틱 업데이트 (즉시 UI 반영)
+        queryClient.setQueryData(['user', userId], (oldData) => {
+          if (oldData) {
+            return {
+              ...oldData,
+              weight: response.data.weight,
+              updatedAt: new Date(),
+            };
+          }
+          return oldData;
+        });
+      }
+    },
+    onError: (error) => {
+      console.error('몸무게 저장 에러: ', error);
+    },
+  });
+
+  return {
+    // 사용자 데이터 관련
+    currentWeight: userData.data?.weight,
+    targetWeight: userData.data?.goals?.targetWeight,
+    isLoading: userData.isLoading,
+    isError: userData.isError,
+    error: userData.error,
+    userData: userData.data, // 전체 사용자 데이터
+
+    // 몸무게 저장 관련
+    saveWeightMutation,
+  };
+};

--- a/yum-yum/src/pages/home/modal/WeightInput.jsx
+++ b/yum-yum/src/pages/home/modal/WeightInput.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { useWeight } from '@/hooks/useWeight';
+
+export default function WeightInput({ register, errors }) {
+  return (
+    <div className='py-10 flex justify-center items-end gap-1'>
+      <div className='flex flex-col items-center gap-1'>
+        <input
+          type='number'
+          className='w-28 text-gray-800 text-5xl font-extrabold text-center border-none outline-none no-spinner'
+          placeholder='0'
+          step='0.1'
+          min='0.0'
+          max='300'
+          {...register('weight', {
+            required: '체중을 입력해주세요',
+            min: { value: 0.1, message: '올바른 체중을 입력해주세요' },
+            max: { value: 300, message: '300kg 이하로 입력해주세요' },
+            pattern: {
+              value: /^\d+\.?\d*$/,
+              message: '숫자만 입력해주세요.',
+            },
+          })}
+        />
+        {errors?.weight && (
+          <div className='absolute mt-16 text-sm text-red-500'>{errors.weight.message}</div>
+        )}
+      </div>
+      <div className='text-gray-700 text-xl font-normal'>kg</div>
+    </div>
+  );
+}

--- a/yum-yum/src/services/userApi.js
+++ b/yum-yum/src/services/userApi.js
@@ -1,0 +1,24 @@
+// services/userApi.js
+import { doc, getDoc } from 'firebase/firestore';
+import { firestore } from './firebase';
+import { mockUser } from '@/data/mockUser';
+
+// 사용자 데이터 가져오기
+export async function getUserData(userId) {
+  try {
+    const userDoc = await getDoc(doc(firestore, 'users', userId));
+
+    if (userDoc.exists()) {
+      return {
+        success: true,
+        data: userDoc.data(),
+      };
+    } else {
+      // Firestore에 데이터가 없는 경우 mock데이터 사용(개발때만 사용)
+      return {
+        success: true,
+        data: mockUser,
+      };
+    }
+  } catch (error) {}
+}

--- a/yum-yum/src/services/weightApi.js
+++ b/yum-yum/src/services/weightApi.js
@@ -1,0 +1,32 @@
+// 메인 페이지 - 몸무게 설정 api 서비스
+import { doc, setDoc } from 'firebase/firestore';
+import { firestore } from './firebase'; //firestore 초기화
+
+// 몸무게 저장
+export async function saveWeight({ userId, weight }) {
+  console.log('saveWeight 호출 - userId:', userId, 'weight:', weight);
+  try {
+    if (!userId || typeof userId !== 'string') {
+      throw new Error(`userId: ${userId}. 유저아이디는 string 값이어야 합니다.`);
+    }
+    if (!weight || typeof weight !== 'number') {
+      throw new Error(`weight: ${weight}. 몸무게 값은 무조건 숫자값이어야 합니다.`);
+    }
+
+    await setDoc(doc(firestore, 'users', userId), {
+      weight: weight,
+    });
+
+    return {
+      success: true,
+      message: '저장 성공',
+      data: { weight },
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+}


### PR DESCRIPTION
## 📝 작업 개요
- 체중 기록 모달창 UI 개발, 기능 개발
- 네비게이션 경로 추가

## 🔨 작업 내용
- 체중 기록 모달 UI 개발
- 체중 기록 시, DB에 weight 저장
- 식단추가 시 식단 추가하는 페이지로 이동

## ✅ 테스트 방법
- localhost:5173 (혹은 다른 포트번호) 실행 -> 메인 페이지 -> 체중 입력 클릭 -> 입력
- 체중 입력 후 저장 기능만 구현 되어있습니다(모달기능만)
<img width="916" height="394" alt="스크린샷 2025-09-09 오후 7 03 31" src="https://github.com/user-attachments/assets/c4aaafbd-65f3-49f3-b595-4d510adaae5e" />
<img width="515" height="375" alt="스크린샷 2025-09-09 오후 7 03 40" src="https://github.com/user-attachments/assets/417c688a-f2c3-48a6-8141-5351f4026ab6" />

## 📎 관련 이슈
-