### PR TITLE
[feat] 직접 등록 탭 리스트 및 음식 상세 정보 모달 추가

### DIFF
--- a/yum-yum/src/pages/meal/MealPage.jsx
+++ b/yum-yum/src/pages/meal/MealPage.jsx
@@ -1,21 +1,23 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
+import FrequentlyEatenFood from './page/FrequentlyEatenFood';
+import CustomEntry from './page/CustomEntry';
 // 컴포넌트
 import MealHeader from './component/MealHeader';
 import MealTabs from './component/MealTabs';
-import FrequentlyEatenFood from './page/FrequentlyEatenFood';
-import CustomEntry from './page/CustomEntry';
 import BasicButton from '@/components/button/BasicButton';
-import { useNavigate } from 'react-router-dom';
 
 const tabItem = [
   { id: 'frequent', label: '자주 먹은 음식' },
   { id: 'custom', label: '직접 등록' },
 ];
+
 export default function MealPage() {
+  const { selectedFoods } = useSelectedFoodsStore();
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState('frequent');
   const [searchInputValue, setSearchInputValue] = useState('');
-  const [searchFood, setSearchFood] = useState('');
-  const navigate = useNavigate();
 
   const onSearchChange = (e) => {
     setSearchInputValue(e.target.value);
@@ -28,6 +30,7 @@ export default function MealPage() {
 
   // 기록하기 버튼
   const handleRecord = () => {
+    console.log(Object.values(selectedFoods));
     navigate('/meal/total');
   };
 
@@ -45,7 +48,9 @@ export default function MealPage() {
 
       <div className='sticky bottom-0 z-30 block w-full max-w-[500px] p-[20px] bg-white'>
         <BasicButton size='full' onClick={handleRecord}>
-          기록하기
+          {Object.keys(selectedFoods).length > 0
+            ? `${Object.keys(selectedFoods).length}개 기록하기`
+            : '기록하기'}
         </BasicButton>
       </div>
     </div>

--- a/yum-yum/src/pages/meal/component/FoodDetailModal.jsx
+++ b/yum-yum/src/pages/meal/component/FoodDetailModal.jsx
@@ -1,28 +1,159 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import { roundTo1, strToNum } from '@/utils/NutrientNumber';
+
 // 컴포넌트
 import Modal from '@/components/Modal';
-export default function FoodDetailModal({ openModal, closeModal, foodInfo }) {
-  const title = foodInfo?.foodName;
+
+export default function FoodDetailModal({ openModal, closeModal, foodInfo, onAddFood }) {
+  if (!openModal) return null;
+
+  const baseSize = strToNum(foodInfo.foodSize); // 기준 내용량
+  const n = foodInfo?.nutrient; // 영양소
+  const [foodSize, setFoodSize] = useState(baseSize);
+
+  const foodStep = 10; // 증가, 감소 단위
+  // + 버튼
+  const handleInc = () => {
+    setFoodSize((v) => Math.max(v + foodStep, 0));
+  };
+  // - 버튼
+  const handleDec = () => {
+    setFoodSize((v) => Math.max(v - foodStep, foodStep));
+  };
+
+  // 현재 내용량 / 기준 내용량
+  const ratio = useMemo(() => (baseSize > 0 ? foodSize / baseSize : 0), [foodSize, baseSize]);
+
+  // 영양소 계산
+  const currentNutrients = useMemo(() => {
+    const scale = (v) => (v == null ? null : roundTo1(strToNum(v) * ratio));
+    return {
+      kcal: n.kcal == null ? null : Math.round(strToNum(n.kcal) * ratio),
+      carbs: scale(n.carbs),
+      sugar: scale(n.sugar),
+      sweetener: scale(n.sweetener),
+      fiber: scale(n.fiber),
+      protein: scale(n.protein),
+      fat: scale(n.fat),
+      satFat: scale(n.satFat),
+      transFat: scale(n.transFat),
+      unsatFat: scale(n.unsatFat),
+      cholesterol: scale(n.cholesterol),
+      sodium: scale(n.sodium),
+      potassium: scale(n.potassium),
+      caffeine: scale(n.caffeine),
+    };
+  }, [n, ratio]);
+
+  const nutritionFields = [
+    { id: 'carbs', label: '탄수화물', value: currentNutrients.carbs, unit: 'g' },
+    { id: 'sugar', label: '- 당', value: currentNutrients.sugar, unit: 'g', subtle: true },
+    {
+      id: 'sweetener',
+      label: '- 대체 감미료',
+      value: currentNutrients.sweetener,
+      unit: 'g',
+      subtle: true,
+    },
+    { id: 'fiber', label: '- 식이섬유', value: currentNutrients.fiber, unit: 'g', subtle: true },
+    { id: 'protein', label: '단백질', value: currentNutrients.protein, unit: 'g' },
+    { id: 'fat', label: '지방', value: currentNutrients.fat, unit: 'g' },
+    { id: 'satFat', label: '- 포화지방', value: currentNutrients.satFat, unit: 'g', subtle: true },
+    {
+      id: 'transFat',
+      label: '- 트랜스지방',
+      value: currentNutrients.transFat,
+      unit: 'g',
+      subtle: true,
+    },
+    {
+      id: 'unsatFat',
+      label: '- 불포화지방',
+      value: currentNutrients.unsatFat,
+      unit: 'g',
+      subtle: true,
+    },
+    { id: 'cholesterol', label: '콜레스테롤', value: currentNutrients.cholesterol, unit: 'mg' },
+    { id: 'sodium', label: '나트륨', value: currentNutrients.sodium, unit: 'mg' },
+    { id: 'potassium', label: '칼륨', value: currentNutrients.potassium, unit: 'mg' },
+    { id: 'caffeine', label: '카페인', value: currentNutrients.caffeine, unit: 'mg' },
+  ];
+
+  const handleAddFoods = () => {
+    const updatedFood = {
+      ...foodInfo,
+      foodSize,
+      nutrient: currentNutrients,
+    };
+    if (onAddFood) onAddFood(updatedFood);
+    closeModal();
+    toast.success('추가 되었습니다');
+  };
 
   return (
-    <Modal isOpenModal={openModal} onCloseModal={closeModal} title={title} btnLabel='추가하기'>
-      <div>
-        <div className='py-[20px] border-t border-gray-200'>
-          <div className='flex justify-between text-sm'>
-            <h5>탄수화물</h5>
-            <p className='font-bold'>10.2g</p>
+    <Modal
+      isOpenModal={openModal}
+      onCloseModal={closeModal}
+      title={foodInfo?.foodName}
+      btnLabel='추가하기'
+      onBtnClick={handleAddFoods}
+      showClose={true}
+    >
+      <div className='flex flex-col gap-[20px] max-h-[calc(100vh-300px)] overflow-y-auto'>
+        <div className='flex gap-[8px]'>
+          <div className='flex items-center justify-between min-w-[226px] h-[48px] border border-[var(--color-gray-300)] rounded-lg'>
+            <button onClick={handleDec} className='w-[44px] text-2xl font-extrabold'>
+              -
+            </button>
+            <input
+              type='text'
+              id='foodSize'
+              step={foodStep}
+              value={foodSize}
+              onChange={(e) => setFoodSize(e.target.value)}
+              onBlur={() => {
+                const newSize = Math.max(strToNum(foodSize), foodStep); // 최소값 제한
+                setFoodSize(roundTo1(newSize));
+              }}
+              className='no-spinner w-[120px] outline-none text-center'
+            />
+            <button onClick={handleInc} className='w-[44px] text-2xl font-extrabold'>
+              +
+            </button>
           </div>
 
-          <div className='flex flex-col gap-[12px] pt-[20px]'>
-            <div className='flex justify-between pl-[20px] text-sm text-gray-500'>
-              <h6>- 당</h6>
-              <p className='font-bold'>10.2g</p>
-            </div>
-            <div className='flex justify-between pl-[20px] text-sm text-gray-500'>
-              <h6>- 당</h6>
-              <p className='font-bold'>10.2g</p>
-            </div>
+          <select className='w-full h-[48px] px-4 border border-[var(--color-gray-300)] rounded-lg transition-colors outline-none'>
+            <option value={foodInfo.foodUnit}>{foodInfo.foodUnit}</option>
+          </select>
+        </div>
+
+        <div>
+          <div className='flex items-center justify-between py-[20px] text-sm font-bold'>
+            <h3>
+              <strong className='text-2xl'>{currentNutrients.kcal}</strong> kcal
+            </h3>
+            <p className='text-gray-500'>
+              총 용량 {foodSize}
+              {foodInfo.foodUnit}
+            </p>
           </div>
+
+          {nutritionFields
+            // 값이 없으면 리스트 숨김
+            .filter((f) => f.value !== null && f.value !== undefined && f.value !== '')
+            .map((f) => (
+              <div
+                key={f.id}
+                className={`flex justify-between items-center py-[16px] text-sm ${f.subtle ? 'border-none text-gray-500' : 'border-t border-gray-200'}`}
+              >
+                <h5 className={`${f.subtle ? 'pl-[20px]' : ''}`}>{f.label}</h5>
+                <p className='font-bold'>
+                  {f.value}
+                  {f.unit}
+                </p>
+              </div>
+            ))}
         </div>
       </div>
     </Modal>

--- a/yum-yum/src/pages/meal/component/FoodItem.jsx
+++ b/yum-yum/src/pages/meal/component/FoodItem.jsx
@@ -8,26 +8,35 @@ export default function FoodItem({
   id,
   foodName,
   makerName,
-  foodWeight,
-  foodCal,
+  foodSize,
+  foodUnit,
+  kcal,
   variant = 'select' /* select, delete */,
   selected = false,
-  onToggleSelect,
-  onDelete,
-  onClick,
+  onSelect,
+  onRemove,
+  onOpenModal,
 }) {
-  const handleSelected = (e) => {
+  // 체크 해제
+  const handleRemove = (e) => {
     e.stopPropagation();
-    onToggleSelect?.();
+    onRemove?.();
   };
 
+  // 추가 선택
+  const handleSelect = (e) => {
+    e.stopPropagation();
+    onSelect?.();
+  };
+
+  // 삭제
   const handleDelete = (e) => {
     e.stopPropagation();
     onDelete();
   };
   return (
     <li
-      onClick={onClick}
+      onClick={onOpenModal}
       className='flex justify-between items-center py-5 border-b border-gray-200'
     >
       <div className='flex flex-col gap-1'>
@@ -35,23 +44,33 @@ export default function FoodItem({
 
         <div className='flex gap-1 text-sm'>
           {makerName && <p className='text-gray-700'>{makerName}</p>}
-          <p className='text-gray-400'>1잔 ({foodWeight}ml)</p>
+          {/* <p className='text-gray-400'>
+            1잔 ({foodSize}
+            {foodUnit})
+          </p> */}
+          <p className='text-gray-400'>
+            {foodSize}
+            {foodUnit}
+          </p>
         </div>
       </div>
 
       <div className='flex gap-3'>
-        {/* 칼로리 */}
-        <div className='font-bold text-gray-500'>{foodCal}kcal</div>
+        <div className='font-bold text-gray-500'>{kcal}kcal</div>
 
         <div className='flex items-center justify-center'>
           {variant === 'select' && (
-            <button onClick={handleSelected} className='flex items-center justify-center'>
+            <>
               {selected ? (
-                <CheckIcon className='text-primary' />
+                <button onClick={handleRemove}>
+                  <CheckIcon className='text-primary' />
+                </button>
               ) : (
-                <PlusIcon className='text-[#CBE9DB] w-[24px] h-[24px]' />
+                <button onClick={handleSelect}>
+                  <PlusIcon className='text-[#CBE9DB] w-[24px] h-[24px]' />
+                </button>
               )}
-            </button>
+            </>
           )}
 
           {variant === 'delete' && (

--- a/yum-yum/src/pages/meal/component/FoodList.jsx
+++ b/yum-yum/src/pages/meal/component/FoodList.jsx
@@ -1,23 +1,34 @@
 import React, { useState } from 'react';
+import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
 // 컴포넌트
 import FoodItem from './FoodItem';
 import FoodDetailModal from './FoodDetailModal';
 
-export default function FoodList({
-  items = [],
-  variant = 'select',
-  selectedIds = [],
-  onToggleSelect,
-  onDelete,
-}) {
+export default function FoodList({ items = [] }) {
+  const { isFoodSelected, addFood, deleteFood } = useSelectedFoodsStore();
   const [openModal, setOpenModal] = useState(false);
   const [selectedFood, setSelectedFood] = useState(null);
 
-  const isSelected = (id) => selectedIds.includes(id);
-
-  const open = (food) => {
+  // 모달 열기
+  const handleOpenModal = (food) => {
     setSelectedFood(food);
     setOpenModal(true);
+  };
+
+  // 음식 추가
+  const handleSelectFood = (food) => {
+    addFood(food);
+  };
+
+  // 음식 제거
+  const handleRemoveFood = (id) => {
+    deleteFood(id);
+  };
+
+  // 모달 닫기
+  const handleCloseModal = () => {
+    setOpenModal(false);
+    setSelectedFood(null);
   };
 
   return (
@@ -26,23 +37,20 @@ export default function FoodList({
         {items.map((food) => (
           <FoodItem
             key={food.id}
-            id={food.id}
-            foodName={food.foodName}
-            makerName={food.makerName}
-            foodWeight={food.foodWeight}
-            foodCal={food.foodCal}
-            onClick={() => open(food)}
-            variant={variant}
-            selected={variant === 'select' ? isSelected(food.id) : false}
-            onToggleSelect={onToggleSelect ? () => onToggleSelect(food.id) : undefined}
-            onDelete={onDelete ? () => onDelete(food.id) : undefined}
+            {...food}
+            selected={isFoodSelected(food.id)}
+            onSelect={() => handleSelectFood(food)}
+            onRemove={() => handleRemoveFood(food.id)}
+            onOpenModal={() => handleOpenModal(food)}
           />
         ))}
       </ul>
+
       <FoodDetailModal
         openModal={openModal}
-        closeModal={() => setOpenModal(false)}
+        closeModal={handleCloseModal}
         foodInfo={selectedFood}
+        onAddFood={handleSelectFood}
       />
     </div>
   );

--- a/yum-yum/src/pages/meal/component/NutritionSection.jsx
+++ b/yum-yum/src/pages/meal/component/NutritionSection.jsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { useCustomFoodStore } from '@/stores/useCustomFoodStore';
+// 컴포넌트
 import Input from '@/components/common/Input';
-import { useCustomFoodStore } from '../../../stores/useCustomFoodStore';
 
 export default function NutritionSection() {
   const nutrient = useCustomFoodStore((state) => state.nutrient);
@@ -33,7 +34,7 @@ export default function NutritionSection() {
         {nutritionFields.map((f) => (
           <div
             key={f.id}
-            className={`flex gap-2 items-center py-[12px] text-sm ${f.subtle ? 'border-none' : 'first:border-t-0 border-t border-gray-300'}`}
+            className={`flex gap-2 items-center py-[12px] text-sm ${f.subtle ? 'border-none' : 'first:border-t-0 border-t border-gray-200'}`}
           >
             <label
               className={`w-full max-w-[226px] ${f.subtle ? 'pl-[20px] text-gray-500' : ''}`}

--- a/yum-yum/src/pages/meal/page/CustomEntry.jsx
+++ b/yum-yum/src/pages/meal/page/CustomEntry.jsx
@@ -1,41 +1,33 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { customFoodsList } from '@/services/customFoodsApi';
 // 컴포넌트
 import EmptyState from '@/components/EmptyState';
+import FoodList from '../component/FoodList';
 // 아이콘
 import SearchIcon from '@/assets/icons/icon-search.svg?react';
-import FoodList from '../component/FoodList';
 
-const foodItems = [
-  {
-    id: '1',
-    foodName: '두유',
-    makerName: '',
-    foodWeight: '200',
-    foodCal: '110',
-  },
-  {
-    id: '2',
-    foodName: '약콩두유',
-    makerName: '대학두유',
-    foodWeight: '190',
-    foodCal: '100',
-  },
-  {
-    id: '3',
-    foodName: '약콩두유',
-    makerName: '대학두유',
-    foodWeight: '190',
-    foodCal: '100',
-  },
-];
+const mockUser = { uid: 'test-user' };
 
-export default function CustomEntry() {
-  const [selectedIds, setSelectedIds] = useState([]);
-  const handleToggleSelect = (id) => {
-    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
-    console.log(id);
-  };
+export default function CustomEntry({ selectedIds, onToggleSelect }) {
+  const [foodItems, setFoodItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchFoods = async () => {
+      try {
+        const data = await customFoodsList(mockUser.uid);
+        setFoodItems(data);
+      } catch (error) {
+        console.error('불러오기 실패:', error);
+        throw error;
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchFoods();
+  }, []);
+
   return (
     <div className='flex flex-col h-full'>
       <div className='flex justify-between items-center px-5 py-3 bg-gray-50'>
@@ -61,7 +53,7 @@ export default function CustomEntry() {
             <FoodList
               variant='select'
               selectedIds={selectedIds}
-              onToggleSelect={handleToggleSelect}
+              onToggleSelect={onToggleSelect}
               items={foodItems}
             />
           ) : (

--- a/yum-yum/src/pages/meal/page/CustomEntryForm.jsx
+++ b/yum-yum/src/pages/meal/page/CustomEntryForm.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
-import { useCustomFoodStore } from '../../../stores/useCustomFoodStore';
-import { addCustomFood } from '../../../services/customFoodsApi';
+import { useCustomFoodStore } from '@/stores/useCustomFoodStore';
+import { addCustomFood } from '@/services/customFoodsApi';
 
 // 컴포넌트
 import MealHeader from '../component/MealHeader';
@@ -26,6 +27,11 @@ export default function CustomEntryForm() {
     createCustomFood,
   } = useCustomFoodStore();
 
+  // 페이지 들어올때 리셋
+  useEffect(() => {
+    reset();
+  }, [reset]);
+
   // 등록 완료 버튼
   const handleSubmitRegister = async () => {
     if (!validate().ok) return;
@@ -36,6 +42,7 @@ export default function CustomEntryForm() {
       const newFoodId = await addCustomFood(mockUser.uid, newFoodData);
 
       reset();
+      toast.success('등록 되었습니다!');
       navigate('/meal');
 
       console.log(newFoodId);

--- a/yum-yum/src/services/customFoodsApi.js
+++ b/yum-yum/src/services/customFoodsApi.js
@@ -1,6 +1,15 @@
 import { firestore } from '@/services/firebase';
-import { collection, doc, setDoc, serverTimestamp } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  setDoc,
+  serverTimestamp,
+  orderBy,
+  query,
+  getDocs,
+} from 'firebase/firestore';
 
+// 직접 입력 음식 등록
 export const addCustomFood = async (userId, newFoodData) => {
   try {
     const customFoodsCol = collection(firestore, 'users', userId, 'customFoods');
@@ -17,6 +26,50 @@ export const addCustomFood = async (userId, newFoodData) => {
     return newFoodDoc.id;
   } catch (error) {
     console.error('직접 등록 중 오류 발생:', error);
+    throw error;
+  }
+};
+
+// 집접 입력 음식 조회
+export const customFoodsList = async () => {
+  try {
+    // const customFoodsCol = collection(firestore, 'users', userId, 'customFoods');
+    const customFoodsCol = collection(firestore, 'users', 'test-user', 'customFoods');
+    const q = query(customFoodsCol, orderBy('createdAt', 'desc'));
+    const querySnapshot = await getDocs(q);
+
+    const groups = querySnapshot.docs.map((doc) => {
+      const data = doc.data();
+      return {
+        id: doc.id,
+        foodName: data.foodName,
+        makerName: data.makerName ?? '',
+        foodSize: data.servingSize,
+        foodUnit: data.servingUnit,
+        kcal: data.nutrient.kcal,
+
+        nutrient: {
+          kcal: data?.nutrient?.kcal ?? undefined,
+          carbs: data?.nutrient?.carbs ?? null,
+          sugar: data?.nutrient?.sugar ?? null,
+          sweetener: data?.nutrient?.sweetener ?? null,
+          fiber: data?.nutrient?.fiber ?? null,
+          protein: data?.nutrient?.protein ?? null,
+          fat: data?.nutrient?.fat ?? null,
+          satFat: data?.nutrient?.satFat ?? null,
+          transFat: data?.nutrient?.transFat ?? null,
+          unsatFat: data?.nutrient?.unsatFat ?? null,
+          cholesterol: data?.nutrient?.cholesterol ?? null,
+          sodium: data?.nutrient?.sodium ?? null,
+          potassium: data?.nutrient?.potassium ?? null,
+          caffeine: data?.nutrient?.caffeine,
+        },
+      };
+    });
+
+    return groups;
+  } catch (error) {
+    console.error('불러오기 중 오류 발생:', error);
     throw error;
   }
 };

--- a/yum-yum/src/stores/useCustomFoodStore.js
+++ b/yum-yum/src/stores/useCustomFoodStore.js
@@ -51,7 +51,7 @@ export const useCustomFoodStore = create((set, get) => ({
       servingSize: Number(foodSize),
       servingUnit: foodUnit,
       nutrient: {
-        kcal: Number(nutrient.kcal), // 칼로리
+        kcal: Math.round(Number(nutrient.kcal)), // 칼로리
         carbs: toNum(nutrient.carbs), // 탄수화물
         sugar: toNum(nutrient.sugar), // 당
         sweetener: toNum(nutrient.sweetener), // 대체감미료

--- a/yum-yum/src/stores/useSelectedFoodsStore.js
+++ b/yum-yum/src/stores/useSelectedFoodsStore.js
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+export const useSelectedFoodsStore = create((set, get) => ({
+  selectedFoods: {},
+  // 음식 선택 여부
+  isFoodSelected: (id) => Boolean(get().selectedFoods[id]),
+
+  // 음식 추가/수정
+  addFood: (food) =>
+    set((state) => ({
+      selectedFoods: { ...state.selectedFoods, [food.id]: food },
+    })),
+
+  // 음식 삭제
+  deleteFood: (id) =>
+    set((state) => {
+      const copy = { ...state.selectedFoods };
+      delete copy[id];
+      return { selectedFoods: copy };
+    }),
+
+  // 전체 삭제
+  clearFoods: () => set({ selectedFoods: {} }),
+}));

--- a/yum-yum/src/utils/NutrientNumber.js
+++ b/yum-yum/src/utils/NutrientNumber.js
@@ -1,2 +1,11 @@
-// 값이 없으면 undefined 있으면 Number
-export const toNum = (v) => (v == null || String(v).trim() === '' ? '-' : Number(v));
+// 값이 없으면 null 있으면 Number
+export const toNum = (v) => (v == null || String(v).trim() === '' ? null : Number(v));
+
+// 숫자면 소수점 한자리까지 반올림
+export const roundTo1 = (v) => (Number.isFinite(v) ? Math.round(v * 10) / 10 : v);
+
+// 문자열을 숫자로 변환
+export const strToNum = (v) => {
+  const n = parseFloat(String(v).replace(',', '.'));
+  return Number.isFinite(n) ? n : 0;
+};


### PR DESCRIPTION
## 📝 작업 개요
- 직접 등록 리스트 및 음식 상세 모달 기능 추가

## 🔨 작업 내용
- 직접 등록 리스트
  - 음식명, 칼로리, 기준 용량 불러옴
  - 우측 + 버튼 클릭 시 선택
  - 리스트 클릭 시 음식 상세 모달 호출
  - 리스트 체크 개수만큼 버튼에 카운트
- 음식 상세 모달
  - +, - 클릭 시 10씩 증가 또는 감소
  - 현재 셀렉트 박스 ml 또는 g 으로만 했음
  - 영양소 정보 있는 값만 불러오기 (영양소가 0인경우도 있어서 null과 0 구분함)
  - 추가하기 버튼 클릭 시 리스트에 체크

## ✅ 테스트 방법
<img width="488" height="896" alt="20250910_163339" src="https://github.com/user-attachments/assets/a8aa5355-fb55-4a86-88e4-ca1ffedfa111" />
<img width="490" height="895" alt="20250910_163355" src="https://github.com/user-attachments/assets/63115d7e-9103-4e06-8404-573657f27913" />

## 📎 관련 이슈

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)
- 직접 등록 리스트
  - 체크 되어있는 음식 상세 모달 호출 시 수정 기능 구현 안되어 있음
- 음식 상세 모달
  - 현재 셀렉트 박스 ml 또는 g으로만 함
