### PR TITLE
[feat] AI API 호출 및 테스트 페이지

### DIFF
--- a/yum-yum/src/App.jsx
+++ b/yum-yum/src/App.jsx
@@ -16,6 +16,7 @@ import RequireGuest from '@/routes/RequireGuest';
 import RequireAuth from '@/routes/RequireAuth';
 import CustomEntryForm from './pages/meal/page/CustomEntryForm';
 import TotalMeal from './pages/meal/page/TotalMeal';
+import TestPage from './pages/home/test/TestPage';
 // import SearchList from './pages/meal/page/SearchList';
 
 const router = createBrowserRouter([
@@ -38,6 +39,7 @@ const router = createBrowserRouter([
           { path: 'meal/total', element: <TotalMeal /> },
           { path: 'report', element: <ReportPage /> },
           { path: 'water', element: <WaterPage /> },
+          { path: 'test', element: <TestPage /> }, //AI report 테스트 페이지(지워야함)
         ],
       },
 

--- a/yum-yum/src/data/timePeriods.js
+++ b/yum-yum/src/data/timePeriods.js
@@ -1,0 +1,19 @@
+// 시간대 정의
+export const TIME_PERIODS = {
+  MORNING: { name: '아침', start: 7, end: 12 },
+  AFTERNOON: { name: '점심', start: 12, end: 17 },
+  EVENING: { name: '저녁', start: 17, end: 22 },
+};
+
+// 현재 시간대 확인
+export function getCurrentTimePeriod(date = null) {
+  const hour = date ? new Date(date)?.getHours() : new Date().getHours();
+  for (const [key, period] of Object.entries(TIME_PERIODS)) {
+    if (hour >= period.start && hour < period.end) {
+      console.log('timeperiod 확인:', period);
+      return { key, ...period };
+    }
+  }
+
+  return null;
+}

--- a/yum-yum/src/hooks/useMeals.js
+++ b/yum-yum/src/hooks/useMeals.js
@@ -1,0 +1,16 @@
+// ai 리포트에서 사용될 식단 가져오는 훅
+
+import { useQuery } from '@tanstack/react-query';
+import { getSelectedData } from '../services/nutritionAnalysis';
+import { parseMeals } from '../utils/mainDataParser';
+
+export function useMeals(userId, selectedDate, type) {
+  return useQuery({
+    queryKey: ['aireport-meals', userId, selectedDate, type],
+    queryFn: () => getSelectedData(userId, selectedDate, type),
+    select: (rawMeals) => parseMeals(rawMeals),
+    staleTime: 1000 * 60 * 5,
+    cacheTime: 1000 * 60 * 30,
+    retry: 1,
+  });
+}

--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -1,0 +1,59 @@
+// AI Api 캐싱, 상태관리
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { generateNutritionAnalysis } from '../services/nutritionAnalysis';
+import { generateDataHash } from '../utils/hashUtils';
+import { getTodayKey } from '../utils/dateUtils';
+import { hasExecutedInTimePeriod, markExecutedInTimePeriod } from '@/utils/localStorage';
+import { useEffect } from 'react';
+
+export const useNutritionAnalysis = (meals, selectedDate, currentTimePeriod) => {
+  const queryClient = useQueryClient();
+  const dataHash = generateDataHash(meals);
+  const today = getTodayKey(selectedDate);
+  const periodKey = currentTimePeriod?.key;
+
+  const queryKey = periodKey
+    ? ['nutrition-analysis', today, periodKey, dataHash]
+    : ['nutrition-analysis', 'invalid-time'];
+  // React-Query 로 쿼리 정의 (enabled: false 로 두고, 직접 fetchQuery 로 실행)
+  const query = useQuery({
+    queryKey: queryKey,
+    queryFn: () => generateNutritionAnalysis(meals[0]),
+    enabled: false,
+    staleTime: 1000 * 60 * 60 * 24,
+    gcTime: 1000 * 60 * 60 * 24 * 7,
+    retry: 2,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
+  // meals가 바뀌거나 currentTimePeriod가 설정되면 이벤트 실행
+  useEffect(() => {
+    if (!meals || !periodKey) return; // 준비 안 된 상태는 패스
+
+    const executed = hasExecutedInTimePeriod(today, periodKey, dataHash);
+    // localStorage를 보고, 아직 호출된 적 없다면 호출
+    if (!executed) {
+      query
+        .refetch()
+        .then(() => {
+          // 성공 시 localStroage에 추가 혹은 업데이트
+          markExecutedInTimePeriod(today, periodKey, dataHash);
+        })
+        .catch((err) => {
+          console.error('마킹 에러발생:', err);
+        });
+    }
+  }, [queryClient, meals, today, periodKey, dataHash, query]);
+
+  // react-query 캐시에 이미 들어있는지 검사
+  const cachedData = queryClient.getQueryData(queryKey);
+  const isCached = cachedData !== undefined;
+  return {
+    ...query,
+    dataHash,
+    todayKey: today,
+    periodKey: currentTimePeriod?.key,
+    isCached,
+  };
+};

--- a/yum-yum/src/pages/home/test/TestPage.jsx
+++ b/yum-yum/src/pages/home/test/TestPage.jsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { getCurrentTimePeriod } from '../../../data/timePeriods';
+import { useMeals } from '../../../hooks/useMeals';
+import { useNutritionAnalysis } from '../../../hooks/useNutritionAnalysis';
+
+const userId = 'yZxviIBudsaf8KYYhCCUWFpy3Ug1'; // test용 ID 추후 쿠키에서 불러오는 방향으로 수정
+export default function TestPage() {
+  const [searchType, setSearchType] = useState('daily');
+  const selectedDate = new Date('2025-09-10');
+  const currentTimePeriod = getCurrentTimePeriod(selectedDate);
+
+  // 1. Firestore 에서 식단 가져오기
+  const {
+    data: meals,
+    isLoading: mealsLoading,
+    isError: mealsError,
+    error: mealsErrorMsg,
+    dataUpdatedAt,
+    status: mealsStatus,
+  } = useMeals(userId, selectedDate, searchType);
+
+  // 2. meals가 준비되면 AI 분석
+  const {
+    data: aiResult,
+    isLoading: aiLoading,
+    isError: aiError,
+    error: aiErrorMsg,
+    status,
+    isCached,
+  } = useNutritionAnalysis(meals, selectedDate, currentTimePeriod);
+
+  // 로딩/에러 처리
+  if (mealsLoading) return <div>식단 불러오는 중…</div>;
+  if (mealsError) return <div>식단 조회 실패: {mealsErrorMsg.message}</div>;
+
+  if (aiLoading) return <div>AI 결과 불러오는 중...</div>;
+  if (aiError) return <div>AI 조회 실패: {aiErrorMsg.message} </div>;
+
+  return (
+    <div className='p-[20px] flex flex-col justify-center item-center text-center'>
+      <h1 className='font-bold text-2xl p-3'>🍎 스마트 식단 분석 Test</h1>
+      <select
+        value={searchType || 'daily'}
+        onChange={(e) => {
+          setSearchType(e.target.value);
+          // useMeals의 훅을 부르는것을 만들어야함
+        }}
+        // style={{ padding: '5px', fontSize: '14px' }}
+        className='p-5 text-lg border rounded-lg mb-4'
+      >
+        <option value='daily'>일간</option>
+        <option value='weekly'>주간</option>
+        <option value='monthly'>월간</option>
+      </select>
+      <div className='mb-4 p-4 bg-gray-100 rounded-lg flex flex-col justify-center item-center text-center'>
+        <h3 className='text-lg font-semibold'>📊 현재 상태</h3>
+        <p>⏰ 분석 날짜: {new Date(selectedDate).toLocaleDateString()}</p>
+        <p>✅ 분석 가능: {currentTimePeriod ? 'Yes' : 'No'}</p>
+        <p>🔄 이번 시간대 실행 여부: {status ? 'Already Executed' : 'Not Executed'}</p>
+        <p>💾 캐시 상태: {isCached ? '✅ Cached' : '🆕 No Cache'}</p>
+        <p>📅 마지막 업데이트: {new Date(dataUpdatedAt).toLocaleString()}</p>
+      </div>
+      <div className='mb-4 p-4 bg-gray-100 rounded-lg flex flex-col justify-center item-center text-center'>
+        {/* 식단 데이터 */}
+        <h3 className='text-lg font-semibold'>식단 데이터</h3>
+        <p>{JSON.stringify(meals, null, 2)}</p>
+      </div>
+      <div className='mb-4 p-4 bg-gray-100 rounded-lg flex flex-col justify-center item-center text-center'>
+        <p className=''>{JSON.stringify(aiResult)}</p>
+      </div>
+    </div>
+  );
+}

--- a/yum-yum/src/services/nutritionAnalysis.js
+++ b/yum-yum/src/services/nutritionAnalysis.js
@@ -1,0 +1,135 @@
+// AI 호출 API
+import { addDoc, collection, getDocs, query, where } from 'firebase/firestore';
+import { firestore, model } from './firebase';
+import { format, startOfMonth } from 'date-fns';
+import { getCurrentTimePeriod } from '../data/timePeriods';
+
+// 프롬프트 생성 함수
+// 일간, 주간, 월간 으로 나뉘어짐. DB 저장할 때 해당 타입, 실행 일자, 필요
+function createPrompt(meals) {
+  return `당신은 영양 전문가입니다. 사용자의 하루 식단 데이터를 분석하여 영양 상태를 평가하고 개선사항을 제안해주세요.
+
+      **분석 기준:**
+      - 성인 기준 1일 권장량: 탄수화물 300-400g, 단백질 50-60g, 지방 50-65g, 나트륨 2000mg 이하, 칼슘 700mg, 비타민C 100mg
+      - 과다/부족 기준: 권장량 대비 120% 이상은 과다, 80% 이하는 부족으로 판단
+      - 결측값(null)이 많은 영양소는 분석에서 제외
+
+      **요청사항:**
+      1-2문장으로 오늘의 영양 상태를 요약하고 개선사항을 제안해주세요.
+      예시: "오늘은 탄수화물과 나트륨 섭취가 적정하지만, 단백질이 부족합니다. 닭가슴살이나 두부 같은 단백질 식품을 추가로 섭취하세요."
+
+      **오늘의 식단 데이터:**
+     ${JSON.stringify(meals, null, 2)}`;
+}
+
+// AI API 호출 함수
+export async function generateNutritionAnalysis(meals) {
+  console.log('AI 호출 시작', meals);
+  if (!meals) {
+    // meals에 아무것도 없을 때
+    return {
+      text: '식단 데이터가 없습니다. 식단을 입력 후 다시 시도해주세요!',
+      timestamp: new Date().toISOString(),
+      generatedAt: new Date().toLocaleTimeString(),
+      timePeriod: getCurrentTimePeriod()?.name || 'Unknown',
+      error: true,
+    };
+  }
+  const prompt = createPrompt(meals);
+  try {
+    // model 호출 및 prompt start
+    const result = await model.generateContent(prompt);
+    const response = result.response;
+    const text = response.text();
+    const data = {
+      success: true,
+      text: text,
+      timestamp: new Date().toISOString(),
+      generatedAt: new Date().toLocaleTimeString(),
+      timePeriod: getCurrentTimePeriod()?.name || 'Unknown',
+    };
+    console.log('ai service', data);
+    return data;
+  } catch (error) {
+    console.error(error);
+    return {
+      text: '영양 분석 중 오류가 발생했습니다.',
+      timestamp: new Date().toISOString(),
+      generatedAt: new Date().toLocaleTimeString(),
+      timePeriod: getCurrentTimePeriod()?.name || 'Unknown',
+      error: true,
+    };
+  }
+}
+
+// ------------------------------
+// Ai Api 호출을 위한 식단 데이터 조회
+export async function getSelectedData(userId, selectedDate, type) {
+  try {
+    // 컬랙션 참조 생성
+    const mealRef = collection(firestore, 'users', userId, 'meal');
+    // type에 따라 쿼리 조건 다르게
+    let mealQuery;
+    if (type === 'daily') {
+      // 하루데이터 = date
+      mealQuery = query(mealRef, where('date', '==', format(selectedDate, 'yyyy-MM-dd')));
+    } else if (type === 'weekly') {
+      // 한 주 데이터
+      const { start, end } = makeWeekRange(selectedDate);
+      mealQuery = query(mealRef, where('date', '>=', start), where('date', '<=', end));
+    } else if (type === 'monthly') {
+      // 달 데이텨
+      const { start, end } = makeMonthRange(selectedDate);
+      mealQuery = query(mealRef, where('date', '>=', start), where('date', '<=', end));
+    }
+    const querySnapshot = await getDocs(mealQuery);
+    const data = querySnapshot.docs.map((docSnap) => ({
+      id: docSnap.id,
+      ...docSnap.data(),
+    }));
+    return {
+      success: true,
+      data,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+}
+
+// AI 메시지 로그 저장
+export async function saveNutritionAnalysis(userId, analysis) {
+  try {
+    const docRef = await addDoc(collection(firestore, 'users', userId, 'aimessage'), {
+      date: analysis.generatedAt,
+      messageType,
+      startDate,
+      endDate,
+      message,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    return {
+      success: true,
+      message: '저장 성공',
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      message: '저장 실패',
+    };
+  }
+}
+
+function makeMonthRange(date) {
+  const start = format(startOfMonth(date), 'yyyy-MM-dd');
+  const end = format(endOfMonth(date), 'yyyy-MM-dd');
+  return { start, end };
+}
+
+function makeWeekRange(date) {}

--- a/yum-yum/src/utils/hashUtils.js
+++ b/yum-yum/src/utils/hashUtils.js
@@ -1,0 +1,12 @@
+// 데이터 해시 생성
+export function generateDataHash(meals) {
+  const dataString = JSON.stringify(meals);
+  const encoder = new TextEncoder();
+  const data = encoder.encode(dataString);
+  let hash = 0;
+  for (let i = 0; i < data.length; i++) {
+    hash = (hash << 5) - hash + data[i];
+    hash != 0;
+  }
+  return Math.abs(hash).toString(16);
+}

--- a/yum-yum/src/utils/localStorage.js
+++ b/yum-yum/src/utils/localStorage.js
@@ -1,0 +1,8 @@
+// AI 호출 관련 임시 저장용 localStorage
+export function markExecutedInTimePeriod(date, timePeriodKey, dataHash) {
+  localStorage.setItem(`nutrition_executed_${date}_${timePeriodKey}_${dataHash}`, 'true');
+}
+
+export function hasExecutedInTimePeriod(date, timePeriodKey, dataHash) {
+  return localStorage.getItem(`nutrition_executed_${date}_${timePeriodKey}_${dataHash}`) === 'true';
+}

--- a/yum-yum/src/utils/mainDataParser.js
+++ b/yum-yum/src/utils/mainDataParser.js
@@ -48,6 +48,41 @@ const parseMealsByType = (meals) => {
   return mealTypes;
 };
 
+// mealType별 데이터 파싱 함수(누적 칼로리, 영양소별 누적값)
+const parseNutritionByType = (meals) => {
+  // 1) 기본 틀
+  const mealTypes = {
+    breakfast: { calories: 0, nutrients: {} },
+    lunch: { calories: 0, nutrients: {} },
+    dinner: { calories: 0, nutrients: {} },
+    snack: { calories: 0, nutrients: {} },
+  };
+
+  if (!meals || meals.length === 0) return mealTypes;
+
+  meals.forEach((meal) => {
+    const bucket = mealTypes[meal.mealType];
+    if (!bucket) return;
+
+    // 2) 칼로리 누적
+    bucket.calories += meal.kcal || 0;
+
+    // 3) 나머지 숫자 필드는 전부 nutrients 에 누적
+    Object.entries(meal).forEach(([key, value]) => {
+      // 제외할 필드 지정
+      if (key === 'mealType' || key === 'kcal' || key === 'foodName') {
+        return;
+      }
+      // 숫자 타입만 누적
+      if (typeof value === 'number' && !isNaN(value)) {
+        bucket.nutrients[key] = (bucket.nutrients[key] || 0) + value;
+      }
+    });
+  });
+
+  return mealTypes;
+};
+
 // 칼로리,탄,단,지 total 값 파싱
 const mealSum = (dailySummary, meals) => {
   if (dailySummary)
@@ -107,4 +142,18 @@ export function normalizerWater(water, age, gender) {
     current: convertMlToL(total),
     goal: convertMlToL(goal),
   };
+}
+
+//--------------------------
+/**
+ * Firebase 에 저장된 로우 데이터를
+ * UI/Api 호출에 적합한 형태로 변환
+ */
+export function parseMeals(rawMeals) {
+  console.log('check: ', rawMeals);
+  return rawMeals.data.map((raw) => ({
+    date: raw.date,
+    totalNutrition: raw.dailySummary,
+    mealBreakdown: parseNutritionByType(raw.meals),
+  }));
 }


### PR DESCRIPTION
## 📝 작업 개요
- AI Api 호출
- AI 리포트에서 필요로 하는 식단 데이터 추출
- 특정 트리거(식단 데이터 변경, 특정 시간대(아침,점심,저녁) 최초 접근)에만 AI 호출
    - 이를 위해 localStorage에 호출 정보(호출한 시간대, 호출 여부) 입력

## 🔨 작업 내용
- Test 페이지 작성(`/pages/home/test/TestPage`)
- 해당 기능을 구현하기 위한 커스텀 훅, Api, utils, data 등 작성

## ✅ 테스트 방법
- 프로젝트 실행 후, [localhost5173](http://localhost:5173/test) 접근
- select 선택 시 바뀌는 이벤트 추가 안함.
- 식단 데이터 및 아래의 메시지(실제 사용할 때는 text만 활용)가 잘 불러왔는지 확인
<img width="1504" height="895" alt="스크린샷 2025-09-12 오후 4 49 47" src="https://github.com/user-attachments/assets/4d9265d7-17fb-490a-9fdd-b0ab39165606" />

## 📎 관련 이슈
- 호출 된 메시지 DB 저장 로직 추가해야 함