### PR TITLE
[fix] 수정 모드 진입 시 기존 식사 데이터 zustand에 로드

### DIFF
--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -50,7 +50,7 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
   const [didFetchCachedResult, setDidFetchCachedResult] = useState(false);
 
   useEffect(() => {
-    console.log(isCached, didFetchCachedResult);
+    // console.log(isCached, didFetchCachedResult);
     if (!hasExecutedInTimePeriod(today, periodKey, dataHash)) return; // 호출 한 적이 없으면 패스
     if (didFetchCachedResult) return; // 이미 한 번 불렀으면 패스
 

--- a/yum-yum/src/pages/home/HomePage.jsx
+++ b/yum-yum/src/pages/home/HomePage.jsx
@@ -25,6 +25,7 @@ import WeightInput from './modal/WeightInput';
 import { useWeight } from '../../hooks/useWeight';
 import { usePageData } from '../../hooks/useMainPageData';
 import { useHomeStore } from '../../stores/useHomeStore';
+import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
 
 registerLocale('ko', ko);
 const userId = 'test-user'; // test용 ID 추후 쿠키에서 불러오는 방향으로 수정
@@ -51,6 +52,7 @@ export default function HomePage() {
   } = useHomeStore();
   const { saveWeightMutation } = useWeight(userId, selectedDate);
   const { userData, dailyData, isLoading, isError } = usePageData(userId, selectedDate);
+  const { clearFoods, addFood } = useSelectedFoodsStore();
 
   const {
     register,
@@ -211,13 +213,18 @@ export default function HomePage() {
                 });
               }}
               onUpdateMeal={(id, mealType) => {
+                clearFoods(); // zustand에 이미 저장되어있는 선택값 clear()
+                // selected zustand에 값 추가
+                const copy = dailyData.mealData[id].meals[mealType];
+                copy.map((meal) => addFood(meal));
                 navigate(`/meal/${mealType}/total`, {
-                  state: { date: selectedDate, formMain: true },
+                  state: { date: selectedDate },
                 });
               }}
               onAddWater={() => {
                 navigate(`/water`, { state: { date: selectedDate } });
               }}
+              wholeData={dailyData}
             />
           </div>
         </BaseCard>

--- a/yum-yum/src/pages/home/card/nutrition/MealCard.jsx
+++ b/yum-yum/src/pages/home/card/nutrition/MealCard.jsx
@@ -38,7 +38,7 @@ const MealCard = ({
                 {section.data.calories > 0 && (
                   <div className='flex items-baseline gap-2'>
                     <span className='text-gray-800 text-2xl font-extrabold'>
-                      {section.data.calories}
+                      {Math.round(section.data?.calories)}
                     </span>
                     <span className='text-pink-500 text-base font-bold'>kcal</span>
                   </div>
@@ -74,8 +74,10 @@ const MealCard = ({
         <div className='flex items-center gap-2'>
           <h3 className='text-gray-800 text-xl font-extrabold'>물</h3>
           <div className='flex items-baseline gap-2'>
-            <span className='text-pink-500 text-2xl font-extrabold'>{water.current}</span>
-            <span className='text-gray-800 text-base font-bold'>/{water.goal}L</span>
+            <span className='text-pink-500 text-2xl font-extrabold'>
+              {water?.current.toFixed(1)}
+            </span>
+            <span className='text-gray-800 text-base font-bold'>/{water?.goal.toFixed(1)}L</span>
           </div>
         </div>
 

--- a/yum-yum/src/pages/home/card/weight/WeightCard.jsx
+++ b/yum-yum/src/pages/home/card/weight/WeightCard.jsx
@@ -39,7 +39,7 @@ export default function WeightCard({ currentWeight = 0, targetWeight = 0, onWeig
               isGoalReached ? 'text-primary' : 'text-secondary'
             }`}
           >
-            {isGoalReached ? '완료!' : `${remainingWegiht}kg!`}
+            {isGoalReached ? '완료!' : `${remainingWegiht?.toFixed(1)}kg!`}
           </div>
         </div>
       </div>

--- a/yum-yum/src/pages/meal/page/FoodSearchResults.jsx
+++ b/yum-yum/src/pages/meal/page/FoodSearchResults.jsx
@@ -24,7 +24,7 @@ export default function FoodSearchResultsPage() {
   useEffect(() => {
     // 검색 로직 추가
     if (searchItem) {
-      console.log('검색 실행:', searchItem);
+      // console.log('검색 실행:', searchItem);
       searchFood(searchItem);
     }
   }, [searchItem]);
@@ -36,7 +36,7 @@ export default function FoodSearchResultsPage() {
 
   // 돋보기 아이콘 클릭, 엔터
   const handleSearchSubmit = () => {
-    console.log(searchInputValue);
+    // console.log(searchInputValue);
     // 같은 페이지로 navigate하되 검색어를 새로 전달
     navigate(`/meal/search`, {
       state: { searchInputValue: searchInputValue },
@@ -54,7 +54,7 @@ export default function FoodSearchResultsPage() {
   // 음식 검색 API 실행 함수
   const searchFood = async (searchItem) => {
     const foods = await fetchNutritionData(searchItem);
-    console.log('파싱된 음식 데이터:', foods);
+    // console.log('파싱된 음식 데이터:', foods);
     setSearchFoodResults(foods);
   };
 

--- a/yum-yum/src/services/nutritionAnalysis.js
+++ b/yum-yum/src/services/nutritionAnalysis.js
@@ -138,7 +138,7 @@ export async function fetchAIResultWithCache(userId, meals) {
 // ------------------------------
 // Ai Api 호출을 위한 식단 데이터 조회
 export async function getSelectedData(userId, selectedDate, type) {
-  console.log(selectedDate);
+  // console.log(selectedDate);
   try {
     // 컬랙션 참조 생성
     const mealRef = collection(firestore, 'users', userId, 'meal');

--- a/yum-yum/src/services/searchFoodApi.js
+++ b/yum-yum/src/services/searchFoodApi.js
@@ -19,7 +19,7 @@ export const fetchNutritionData = async (searchKeyword = '') => {
     }
 
     const jsonData = await response.json();
-    console.log('원본 데이터:', jsonData);
+    // console.log('원본 데이터:', jsonData);
 
     // 데이터 구조에 따라 파싱
     return parseNutritionData(jsonData);

--- a/yum-yum/src/utils/mainDataParser.js
+++ b/yum-yum/src/utils/mainDataParser.js
@@ -25,13 +25,14 @@ const parseMealsByType = (meals) => {
     snack: { calories: 0, foods: null },
   };
   if (!meals || meals.length === 0) return mealTypes;
-
+  console.log(meals);
   // mealType별로 그룹화 -> Object.entries()로 키-값 쌍을 배열로 변환
   Object.entries(meals).forEach(([mealType, mealArray]) => {
     if (mealTypes[mealType] && Array.isArray(mealArray)) {
       mealArray.forEach((meal) => {
+        console.log(meal);
         // 칼로리 누적
-        mealTypes[mealType].calories += meal.kcal || 0;
+        mealTypes[mealType].calories += meal.nutrient.kcal || 0;
 
         // 음식 이름 누적
         if (meal.foodName) {
@@ -117,9 +118,9 @@ export function normalizerMeal(meal) {
   if (!meal) return null;
   // 칼로리,탄,단,지 통합 구하기
   const { calories, carbs, protein, fat } = mealSum(meal.dailySummary, meal.meals);
-  // console.log(meal);
   //mealType별 데이터 파싱
   const mealsByType = parseMealsByType(meal.meals);
+  console.log(mealsByType);
 
   // return null;
   return {

--- a/yum-yum/src/utils/mainDataParser.js
+++ b/yum-yum/src/utils/mainDataParser.js
@@ -25,12 +25,12 @@ const parseMealsByType = (meals) => {
     snack: { calories: 0, foods: null },
   };
   if (!meals || meals.length === 0) return mealTypes;
-  console.log(meals);
+  // console.log(meals);
   // mealType별로 그룹화 -> Object.entries()로 키-값 쌍을 배열로 변환
   Object.entries(meals).forEach(([mealType, mealArray]) => {
     if (mealTypes[mealType] && Array.isArray(mealArray)) {
       mealArray.forEach((meal) => {
-        console.log(meal);
+        // console.log(meal);
         // 칼로리 누적
         mealTypes[mealType].calories += meal.nutrient?.kcal || 0;
 
@@ -120,7 +120,7 @@ export function normalizerMeal(meal) {
   const { calories, carbs, protein, fat } = mealSum(meal.dailySummary, meal.meals);
   //mealType별 데이터 파싱
   const mealsByType = parseMealsByType(meal.meals);
-  console.log(mealsByType);
+  // console.log(mealsByType);
 
   // return null;
   return {

--- a/yum-yum/src/utils/mainDataParser.js
+++ b/yum-yum/src/utils/mainDataParser.js
@@ -32,7 +32,7 @@ const parseMealsByType = (meals) => {
       mealArray.forEach((meal) => {
         console.log(meal);
         // 칼로리 누적
-        mealTypes[mealType].calories += meal.nutrient.kcal || 0;
+        mealTypes[mealType].calories += meal.nutrient?.kcal || 0;
 
         // 음식 이름 누적
         if (meal.foodName) {


### PR DESCRIPTION
## 📝 작업 개요
- 식사 수정 기능에서 기존에 저장된 음식 데이터가 수정 페이지에 반영되지 않는 문제 수정
- 수정 모드 진입 시 zustand store와 기존 데이터 간의 동기화 처리

## 🔨 작업 내용
- `onUpdateMeal` 함수에서 기존 선택 데이터 초기화 로직 추가 (`clearFoods()`)
- `addFood(meal)` : 기존 식사 데이터를 zustand store에 로드하는 기능 구현 
- 수정 페이지로 이동 시 기존 음식 선택 상태가 올바르게 복원되도록 수정

## ✅ 테스트 방법
1. 기존에 음식이 등록된 식사 항목 선택
2. 수정 버튼 클릭하여 수정 모드 진입
3. 기존에 선택했던 음식들이 선택된 상태로 화면에 표시되어야 함
4. 음식 추가/제거 후 저장하여 정상적으로 업데이트되는지 확인

## 📎 관련 이슈
- 식사 수정 시 기존 선택 상태 미반영 문제 해결

### 🚨 추가 이슈 사항
- 추가, 수정, 삭제 이후 메인화면 돌아왔을 때, 업데이트가 안되고 있음