### PR TITLE
[fix] 식단 데이터 타입 불일치로 인한 칼로리 표시 및 파싱 오류 해결 #60

### DIFF
--- a/yum-yum/src/pages/home/card/weight/WeightCard.jsx
+++ b/yum-yum/src/pages/home/card/weight/WeightCard.jsx
@@ -39,7 +39,12 @@ export default function WeightCard({ currentWeight = 0, targetWeight = 0, onWeig
               isGoalReached ? 'text-primary' : 'text-secondary'
             }`}
           >
-            {isGoalReached ? '완료!' : `${remainingWegiht?.toFixed(1)}kg!`}
+            {/* 감소는 - 증가는 + 표시 */}
+            {isGoalReached
+              ? '완료!'
+              : remainingWegiht && remainingWegiht < 0
+                ? `${remainingWegiht?.toFixed(1)}kg!`
+                : `+${remainingWegiht?.toFixed(1)}kg!`}
           </div>
         </div>
       </div>

--- a/yum-yum/src/pages/meal/page/FoodSearchResults.jsx
+++ b/yum-yum/src/pages/meal/page/FoodSearchResults.jsx
@@ -39,7 +39,7 @@ export default function FoodSearchResultsPage() {
     // console.log(searchInputValue);
     // 같은 페이지로 navigate하되 검색어를 새로 전달
     navigate(`/meal/search`, {
-      state: { searchInputValue: searchInputValue },
+      state: { searchInputValue: searchInputValue, type: type, date: date },
       replace: false,
     });
   };

--- a/yum-yum/src/utils/mainDataParser.js
+++ b/yum-yum/src/utils/mainDataParser.js
@@ -104,12 +104,22 @@ const mealSum = (dailySummary, meals) => {
     totalCarbs = 0,
     totalProtein = 0,
     totalFat = 0;
-  meals.map((meal) => {
-    totalCalories += meal?.calorie ?? 0;
-    totalCarbs += meal?.carbs ?? 0;
-    totalProtein += meal?.protein ?? 0;
-    totalFat += meal?.fat ?? 0;
-  });
+  // console.log(meals);
+  if (!Array.isArray(meals)) {
+    Object.keys(meals)?.map((meal) => {
+      totalCalories += meal?.calorie ?? 0;
+      totalCarbs += meal?.carbs ?? 0;
+      totalProtein += meal?.protein ?? 0;
+      totalFat += meal?.fat ?? 0;
+    });
+  } else {
+    meals.map((meal) => {
+      totalCalories += meal?.calorie ?? 0;
+      totalCarbs += meal?.carbs ?? 0;
+      totalProtein += meal?.protein ?? 0;
+      totalFat += meal?.fat ?? 0;
+    });
+  }
   return { calories: totalCalories, carbs: totalCarbs, protein: totalProtein, fat: totalFat };
 };
 


### PR DESCRIPTION
## 📝 작업 개요
- 식단 입력 시 데이터 타입이 올바르게 저장되지 않아 두 가지 문제가 발생:
1. 음식을 검색하여 식단을 입력할 때, undefinded type으로 입력됨
2. Object 형태로 전달되어 `.map()` 함수 사용 불가

## 🔨 작업 내용
- `mainDataParse`: `mealSum` 함수에서 `Array.isArray(meals)` 체크 후 `Object.values(meals)` 사용
- `FoodSearchResults`에서 여러번 검색하는 경우 `navigate`의 `state`에 타입과 날짜 전달

## ✅ 테스트 방법
- 

## 📎 관련 이슈
- Close #60 