### PR TITLE
[fix] 홈페이지에서 물/식단 추가 후 돌아올 때 변경사항이 반영되지 않는 문제 #59

### DIFF
--- a/yum-yum/src/hooks/useMainPageData.js
+++ b/yum-yum/src/hooks/useMainPageData.js
@@ -18,7 +18,8 @@ export const usePageData = (userId, selectedDate) => {
     queryKey: ['dailyData', userId, selectedDate],
     queryFn: () => getDailyData(userId, selectedDate),
     select: (resp) => resp.data,
-    staleTime: 1 * 60 * 1000, // 1분
+    // staleTime: 1 * 60 * 1000, // 1분
+    staleTime: 30 * 1000, // 30초
     enabled: !!userId && !!selectedDate,
   });
 


### PR DESCRIPTION
## 📝 작업 개요
- 홈페이지에서 물/식단 추가 후 돌아올 때 변경사항이 반영되지 않음
- 추가를 한 번 진행하고, 바로 진행하는 경우에만 변경사항이 적용되지않고 캐싱된 데이터가 뿌려짐

## 🔨 작업 내용
- staleTime을 줄여서 시도하니 최신데이터를 불러옴
- staleTime 범위를 30초로 수정

## ✅ 테스트 방법
-

## 📎 관련 이슈
- Close #59 