### PR TITLE
[Feat] 식단 리포트 데이터 연동

### DIFF
--- a/yum-yum/src/hooks/useReportData.js
+++ b/yum-yum/src/hooks/useReportData.js
@@ -1,0 +1,86 @@
+import { useQuery } from '@tanstack/react-query';
+import { getUserData } from '../services/userApi';
+import { query } from 'firebase/firestore';
+import { getEndDateOfMonth, getEndDateOfWeek, getStartDateOfMonth, getStartDateOfWeek, parseDateString } from '../utils/dateUtils';
+import { getWeeklyData } from '../services/weeklyDataApi';
+import { normalizeDataRange } from './../utils/reportDataParser';
+import { getMonthlyData } from '../services/monthlyDataApi';
+
+export const useWeeklyReportData = (userId, selectedDate) => {
+  // 단위 기간 범위 설정
+  const startDay = parseDateString(getStartDateOfWeek(selectedDate));
+  const endDay = parseDateString(getEndDateOfWeek(selectedDate));
+
+  const startOfDay = new Date(startDay.year, startDay.month - 1, startDay.date);
+  const endOfDay = new Date(endDay.year, endDay.month - 1, endDay.date);
+
+  // 사용자 데이터 불러오기
+  const userQuery = useQuery({
+    queryKey: ['user', userId],
+    queryFn: () => getUserData(userId),
+    select: (response) => response.data,
+    staleTime: 10 * 60 * 1000, // 10분
+    enabled: !!userId, // userId가 있을 때만 실행
+  });
+
+  const weeklyDataQuery = useQuery({
+    queryKey: ['mealData', userId, selectedDate, 'weekly'],
+    queryFn: () => getWeeklyData(userId, startOfDay, endOfDay),
+    select: (response) => response.data,
+    staleTime: 1 * 60 * 1000, // 1분
+    enabled: !!userId && !!selectedDate,
+  });
+
+  return {
+    // 사용자 데이터
+    userData: userQuery.data,
+    userLoading: userQuery.isLoading,
+
+    // 데이터
+    weeklyData: weeklyDataQuery.data,
+    weeklyLoading: weeklyDataQuery.isLoading,
+
+    // 전체 로딩 상태
+    isLoading: userQuery.isLoading || weeklyDataQuery.isLoading,
+  };
+};
+
+
+export const useMonthlyReportData = (userId, selectedDate) => {
+  // 단위 기간 범위 설정
+  const startDay = parseDateString(getStartDateOfMonth(selectedDate));
+  const endDay = parseDateString(getEndDateOfMonth(selectedDate));
+
+  const startOfDay = new Date(startDay.year, startDay.month - 1, startDay.date);
+  const endOfDay = new Date(endDay.year, endDay.month - 1, endDay.date);
+
+  // 사용자 데이터 불러오기
+  const userQuery = useQuery({
+    queryKey: ['user', userId],
+    queryFn: () => getUserData(userId),
+    select: (response) => response.data,
+    staleTime: 10 * 60 * 1000, // 10분
+    enabled: !!userId, // userId가 있을 때만 실행
+  });
+
+  const monthlyDataQuery = useQuery({
+    queryKey: ['mealData', userId, selectedDate, 'monthly'],
+    queryFn: () => getMonthlyData(userId, startOfDay, endOfDay),
+    select: (response) => response.data,
+    staleTime: 1 * 60 * 1000, // 1분
+    enabled: !!userId && !!selectedDate,
+  });
+  
+  return {
+    // 사용자 데이터
+    userData: userQuery.data,
+    userLoading: userQuery.isLoading,
+
+    // 데이터
+    monthlyData: monthlyDataQuery.data,
+    monthlyLoading: monthlyDataQuery.isLoading,
+
+    // 전체 로딩 상태
+    isLoading: userQuery.isLoading || monthlyDataQuery.isLoading,
+  };
+};

--- a/yum-yum/src/hooks/useReportData.js
+++ b/yum-yum/src/hooks/useReportData.js
@@ -1,10 +1,53 @@
 import { useQuery } from '@tanstack/react-query';
 import { getUserData } from '../services/userApi';
-import { query } from 'firebase/firestore';
-import { getEndDateOfMonth, getEndDateOfWeek, getStartDateOfMonth, getStartDateOfWeek, parseDateString } from '../utils/dateUtils';
+import {
+  getEndDateOfMonth,
+  getEndDateOfWeek,
+  getStartDateOfMonth,
+  getStartDateOfWeek,
+  parseDateString,
+} from '../utils/dateUtils';
 import { getWeeklyData } from '../services/weeklyDataApi';
-import { normalizeDataRange } from './../utils/reportDataParser';
 import { getMonthlyData } from '../services/monthlyDataApi';
+import { getDailyData } from '../services/dailyDataApi';
+import { getTodayKey } from './../utils/dateUtils';
+
+export const useDailyReportData = (userId, selectedDate) => {
+  // 단위 기간 범위 설정
+  const day = parseDateString(selectedDate);
+
+  const newDate = getTodayKey(new Date(day.year, day.month - 1, day.date));
+
+  // 사용자 데이터 불러오기
+  const userQuery = useQuery({
+    queryKey: ['user', userId],
+    queryFn: () => getUserData(userId),
+    select: (response) => response.data,
+    staleTime: 10 * 60 * 1000,
+    enabled: !!userId,
+  });
+
+  const dailyDataQuery = useQuery({
+    queryKey: ['mealData', userId, selectedDate, 'daily'],
+    queryFn: () => getDailyData(userId, newDate),
+    select: (response) => response.data,
+    staleTime: 0.5 * 60 * 1000, // 1분
+    enabled: !!userId && !!selectedDate,
+  });
+
+  return {
+    // 사용자 데이터
+    userData: userQuery.data,
+    userLoading: userQuery.isLoading,
+
+    // 데이터
+    dailyData: dailyDataQuery.data,
+    dailyLoading: dailyDataQuery.isLoading,
+
+    // 전체 로딩 상태
+    isLoading: userQuery.isLoading || dailyDataQuery.isLoading,
+  };
+};
 
 export const useWeeklyReportData = (userId, selectedDate) => {
   // 단위 기간 범위 설정
@@ -27,7 +70,7 @@ export const useWeeklyReportData = (userId, selectedDate) => {
     queryKey: ['mealData', userId, selectedDate, 'weekly'],
     queryFn: () => getWeeklyData(userId, startOfDay, endOfDay),
     select: (response) => response.data,
-    staleTime: 1 * 60 * 1000, // 1분
+    staleTime: 0.5 * 60 * 1000, // 1분
     enabled: !!userId && !!selectedDate,
   });
 
@@ -44,7 +87,6 @@ export const useWeeklyReportData = (userId, selectedDate) => {
     isLoading: userQuery.isLoading || weeklyDataQuery.isLoading,
   };
 };
-
 
 export const useMonthlyReportData = (userId, selectedDate) => {
   // 단위 기간 범위 설정
@@ -67,10 +109,10 @@ export const useMonthlyReportData = (userId, selectedDate) => {
     queryKey: ['mealData', userId, selectedDate, 'monthly'],
     queryFn: () => getMonthlyData(userId, startOfDay, endOfDay),
     select: (response) => response.data,
-    staleTime: 1 * 60 * 1000, // 1분
+    staleTime: 0.5 * 60 * 1000,
     enabled: !!userId && !!selectedDate,
   });
-  
+
   return {
     // 사용자 데이터
     userData: userQuery.data,

--- a/yum-yum/src/pages/report/charts/PieCharts.jsx
+++ b/yum-yum/src/pages/report/charts/PieCharts.jsx
@@ -1,13 +1,26 @@
 import React from 'react';
 import { PieChart, Pie, Cell, Legend } from 'recharts';
 
-export default function PieCharts({ data = [] }) {
+export default function PieCharts({ data }) {
   const PALETTES = ['#FF5094', '#2F73E5', '#FFD653'];
 
   // 데이터 가공. 입력된 데이터가 없을 땐 0으로 처리
   const chartData =
-    data.length > 0
-      ? data
+    data && Object.keys(data).length > 0 
+      ? [
+          {
+            name: '탄수화물',
+            value: data.totalCarbs ?? 0,
+          },
+          {
+            name: '단백질',
+            value: data.totalProtein ?? 0,
+          },
+          {
+            name: '지방',
+            value: data.totalFats ?? 0,
+          },
+        ]
       : [
           { name: '탄수화물', value: 0 },
           { name: '단백질', value: 0 },
@@ -39,7 +52,15 @@ export default function PieCharts({ data = [] }) {
     const y = cy + radius * Math.sin(-midAngle * RADIAN);
 
     return (
-      <text x={x} y={y} fill='white' textAnchor='middle' dominantBaseline='central' fontSize={16} fontWeight={400}>
+      <text
+        x={x}
+        y={y}
+        fill='white'
+        textAnchor='middle'
+        dominantBaseline='central'
+        fontSize={16}
+        fontWeight={400}
+      >
         {total === 0 ? '0%' : `${(percent * 100).toFixed(0)}%`}
       </text>
       // 값이 없을때 0% 표기

--- a/yum-yum/src/pages/report/charts/PieCharts.jsx
+++ b/yum-yum/src/pages/report/charts/PieCharts.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import { PieChart, Pie, Cell, Legend } from 'recharts';
+import { calculateNutrientRatio } from '../../../utils/calorieCalculator';
+
+const safeNumber = (val) => {
+  const num = typeof val === 'number' ? val : Number(val);
+  return Number.isFinite(num) ? parseFloat(num.toFixed(1)) : 0;
+};
 
 export default function PieCharts({ data }) {
   const PALETTES = ['#FF5094', '#2F73E5', '#FFD653'];
+
+  const {carbsRatio, proteinsRatio, fatsRatio} = calculateNutrientRatio(data.totalCarbs, data.totalProtein, data.totalFat)
 
   // 데이터 가공. 입력된 데이터가 없을 땐 0으로 처리
   const chartData =
@@ -10,30 +18,34 @@ export default function PieCharts({ data }) {
       ? [
           {
             name: '탄수화물',
-            value: data.totalCarbs ?? 0,
+            value: carbsRatio,
+            gram: safeNumber(data.totalCarbs)
+            
           },
           {
             name: '단백질',
-            value: data.totalProtein ?? 0,
+            value: proteinsRatio, 
+            gram: safeNumber(data.totalProtein),
           },
           {
             name: '지방',
-            value: data.totalFats ?? 0,
+            value: fatsRatio,
+            gram: safeNumber(data.totalFat),
           },
         ]
       : [
-          { name: '탄수화물', value: 0 },
-          { name: '단백질', value: 0 },
-          { name: '지방', value: 0 },
+          { name: '탄수화물', value: 0, gram: 0 },
+          { name: '단백질', value: 0, gram: 0 },
+          { name: '지방', value: 0, gram: 0 },
         ];
 
   // 합계 계산
-  const total = chartData.reduce((sum, d) => sum + d.value, 0);
+  const total = chartData.reduce((sum, d) => sum + d.gram, 0);
 
   // 파이 차트에 사용할 데이터. 데이터가 없을 때 따로 처리
   const pieData =
     total === 0
-      ? chartData.map((d) => ({ ...d, value: 1 })) // 0일 땐 균등하게 1씩
+      ? chartData.map((d) => ({ ...d, gram: 1 })) // 0일 땐 균등하게 1씩
       : chartData;
 
   const renderCustomizedLabel = ({
@@ -106,7 +118,7 @@ export default function PieCharts({ data }) {
             // 범례 값 출력 한 줄로 출력하도록
             <div className='inline-block text-center w-20 align-middle text-black'>
               <div>{value}</div>
-              <div className='mt-1'>{item?.value ?? 0}g</div>
+              <div className='mt-1'>{item?.gram ?? 0}g</div>
             </div>
           );
         }}

--- a/yum-yum/src/pages/report/components/ChartArea.jsx
+++ b/yum-yum/src/pages/report/components/ChartArea.jsx
@@ -79,7 +79,7 @@ export default function ChartArea({
         </article>
       )}
 
-      {value && unit !== 'AI' && (
+      {value !== null && value !== undefined && unit !== 'AI' && (
         <article className='flex items-end gap-2'>
           <span className='text-2xl font-bold'>
             {periodPrefix} {unitInfo.prefix} :{' '}

--- a/yum-yum/src/pages/report/components/ChartArea.jsx
+++ b/yum-yum/src/pages/report/components/ChartArea.jsx
@@ -84,7 +84,7 @@ export default function ChartArea({
           <span className='text-2xl font-bold'>
             {periodPrefix} {unitInfo.prefix} :{' '}
           </span>
-          <span className='text-4xl font-bold'>{value}</span>
+          <span className='text-4xl font-bold'>{value.toFixed(1)}</span>
           <span className='text-2xl font-bold'> {unitInfo.postfix}</span>
         </article>
       )}

--- a/yum-yum/src/pages/report/components/NutritionInfo.jsx
+++ b/yum-yum/src/pages/report/components/NutritionInfo.jsx
@@ -12,14 +12,14 @@ const safeFormatPercent = (value) => {
 
 
 function InfoData({ label, percent, value, isSub }) {
-  const textStyle = clsx('w-30 font-bold text-2xl', isSub && 'text-gray-500 text-xl font-normal');
+  const textStyle = clsx('font-bold text-2xl', isSub && 'text-gray-500 text-xl font-normal');
   // 음식 정보 상세
 
   return (
     <div className='w-full flex flex-row items-center justify-around'>
-      <span className={textStyle}>{label}</span>
-      <span className={clsx(textStyle, 'text-center')}>{percent ? percent : ''} </span>
-      <span className={clsx(textStyle, 'text-right')}>{value}</span>
+      <span className={clsx(textStyle, 'w-35')}>{label}</span>
+      <span className={clsx(textStyle, 'text-center', 'w-20')}>{percent ? percent : ''} </span>
+      <span className={clsx(textStyle, 'text-right', 'w-35')}>{value}</span>
     </div>
   );
 }
@@ -44,54 +44,52 @@ export default function NutritionInfo({ nutritionData }) {
 
   const {carbsRatio, proteinsRatio, fatsRatio} = calculateNutrientRatio(nutritionData.totalCarbs, nutritionData.totalProtein, nutritionData.totalFat)
 
-  console.log(carbsRatio, proteinsRatio, fatsRatio)
-
     // 매핑 필드
   const nutritionMapping = [
     {
       label: '총 열량',
       percent: '',
-      value: `${nutritionData.totalCalories ?? 0} Kcal`,
+      value: `${nutritionData.totalCalories?.toFixed(1) ?? 0} Kcal`,
     },
     {
       label: '탄수화물',
       percent: safeFormatPercent(carbsRatio),
-      value: `${nutritionData.totalCarbs ?? 0} g`,
+      value: `${nutritionData.totalCarbs?.toFixed(1) ?? 0} g`,
       subs: [
-        { label: '당류', value: `${nutritionData.totalSugar ?? 0} g`, isSub: true },
-        { label: '대체감미료', value: `${nutritionData.totalSweetener ?? 0} g`, isSub: true },
-        { label: '식이섬유', value: `${nutritionData.totalFiber ?? 0} g`, isSub: true },
+        { label: '당류', value: `${nutritionData.totalSugar?.toFixed(1) ?? 0} g`, isSub: true },
+        { label: '대체감미료', value: `${nutritionData.totalSweetener?.toFixed(1) ?? 0} g`, isSub: true },
+        { label: '식이섬유', value: `${nutritionData.totalFiber?.toFixed(1) ?? 0} g`, isSub: true },
       ],
     },
     {
       label: '단백질',
       percent: safeFormatPercent(proteinsRatio),
-      value: `${nutritionData.totalProtein ?? 0} g`,
+      value: `${nutritionData.totalProtein?.toFixed(1) ?? 0} g`,
     },
     {
       label: '지방',
       percent:  safeFormatPercent(fatsRatio),
-      value: `${nutritionData.totalFat ?? 0} g`,
+      value: `${nutritionData.totalFat?.toFixed(1) ?? 0} g`,
       subs: [
-        { label: '포화지방산', value: `${nutritionData.totalSaturatedFat ?? 0} g`, isSub: true },
-        { label: '트랜스지방', value: `${nutritionData.totalTransFat ?? 0} g`, isSub: true },
-        { label: '불포화지방', value: `${nutritionData.totalUnsaturatedFat ?? 0} g`, isSub: true },
+        { label: '포화지방산', value: `${nutritionData.totalSaturatedFat?.toFixed(1) ?? 0} g`, isSub: true },
+        { label: '트랜스지방', value: `${nutritionData.totalTransFat?.toFixed(1) ?? 0} g`, isSub: true },
+        { label: '불포화지방', value: `${nutritionData.totalUnsaturatedFat?.toFixed(1) ?? 0} g`, isSub: true },
       ],
     },
     {
       label: '콜레스테롤',
       percent: '',
-      value: `${nutritionData.totalCholesterol ?? 0} mg`,
+      value: `${nutritionData.totalCholesterol?.toFixed(1) ?? 0} mg`,
     },
     {
       label: '나트륨',
       percent: '',
-      value: `${nutritionData.totalSodium ?? 0} mg`,
+      value: `${nutritionData.totalSodium?.toFixed(1) ?? 0} mg`,
     },
     {
       label: '카페인',
       percent: '',
-      value: `${nutritionData.totalCaffeine ?? 0} mg`,
+      value: `${nutritionData.totalCaffeine?.toFixed(1) ?? 0} mg`,
     },
   ];
 

--- a/yum-yum/src/pages/report/components/NutritionInfo.jsx
+++ b/yum-yum/src/pages/report/components/NutritionInfo.jsx
@@ -1,14 +1,24 @@
 import clsx from 'clsx';
 import React from 'react';
+import { calculateNutrientRatio } from '../../../utils/calorieCalculator';
+
+
+const safeFormatPercent = (value) => {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return `${value} %`;
+  }
+  return ''; // undefined, NaN, null 등은 빈 문자열
+};
+
 
 function InfoData({ label, percent, value, isSub }) {
   const textStyle = clsx('w-30 font-bold text-2xl', isSub && 'text-gray-500 text-xl font-normal');
-
   // 음식 정보 상세
+
   return (
     <div className='w-full flex flex-row items-center justify-around'>
       <span className={textStyle}>{label}</span>
-      <span className={clsx(textStyle, 'text-center')}>{percent === '' ? percent : ''} </span>
+      <span className={clsx(textStyle, 'text-center')}>{percent ? percent : ''} </span>
       <span className={clsx(textStyle, 'text-right')}>{value}</span>
     </div>
   );
@@ -30,52 +40,58 @@ function InfoSection({ rowData }) {
 }
 
 export default function NutritionInfo({ nutritionData }) {
-  // 매핑 필드
+  // console.log(nutritionData)
+
+  const {carbsRatio, proteinsRatio, fatsRatio} = calculateNutrientRatio(nutritionData.totalCarbs, nutritionData.totalProtein, nutritionData.totalFat)
+
+  console.log(carbsRatio, proteinsRatio, fatsRatio)
+
+    // 매핑 필드
   const nutritionMapping = [
     {
       label: '총 열량',
       percent: '',
-      value: `${nutritionData.kcal} Kcal`,
+      value: `${nutritionData.totalCalories ?? 0} Kcal`,
     },
     {
       label: '탄수화물',
-      percent: '40%',
-      value: `${nutritionData.carbs} g`,
+      percent: safeFormatPercent(carbsRatio),
+      value: `${nutritionData.totalCarbs ?? 0} g`,
       subs: [
-        { label: '당류', value: `${nutritionData.sugar} g`, isSub: true },
-        { label: '대체감미료', value: `${nutritionData.sweetener} g`, isSub: true },
-        { label: '식이섬유', value: `${nutritionData.fiber} g`, isSub: true },
+        { label: '당류', value: `${nutritionData.totalSugar ?? 0} g`, isSub: true },
+        { label: '대체감미료', value: `${nutritionData.totalSweetener ?? 0} g`, isSub: true },
+        { label: '식이섬유', value: `${nutritionData.totalFiber ?? 0} g`, isSub: true },
       ],
     },
     {
       label: '단백질',
-      percent: '30%',
-      value: `${nutritionData.protein} g`,
+      percent: safeFormatPercent(proteinsRatio),
+      value: `${nutritionData.totalProtein ?? 0} g`,
     },
     {
       label: '지방',
-      percent: '30%',
-      value: `${nutritionData.fat} g`,
+      percent:  safeFormatPercent(fatsRatio),
+      value: `${nutritionData.totalFat ?? 0} g`,
       subs: [
-        { label: '포화지방산', value: `${nutritionData.satFat} g`, isSub: true },
-        { label: '트랜스지방', value: `${nutritionData.transFat} g`, isSub: true },
-        { label: '불포화지방', value: `${nutritionData.unsatFat} g`, isSub: true },
+        { label: '포화지방산', value: `${nutritionData.totalSaturatedFat ?? 0} g`, isSub: true },
+        { label: '트랜스지방', value: `${nutritionData.totalTransFat ?? 0} g`, isSub: true },
+        { label: '불포화지방', value: `${nutritionData.totalUnsaturatedFat ?? 0} g`, isSub: true },
       ],
     },
     {
       label: '콜레스테롤',
       percent: '',
-      value: `${nutritionData.cholesterol} mg`,
+      value: `${nutritionData.totalCholesterol ?? 0} mg`,
     },
     {
       label: '나트륨',
       percent: '',
-      value: `${nutritionData.sodium} mg`,
+      value: `${nutritionData.totalSodium ?? 0} mg`,
     },
     {
       label: '카페인',
       percent: '',
-      value: `${nutritionData.caffeine} mg`,
+      value: `${nutritionData.totalCaffeine ?? 0} mg`,
     },
   ];
 

--- a/yum-yum/src/pages/report/pages/AiReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/AiReportPage.jsx
@@ -1,9 +1,23 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ChartArea from '../components/ChartArea';
 
-import LightBulbIcon from '@/assets/icons/icon-light-bulb.svg?react';
+import { getTodayKey, parseDateString } from '../../../utils/dateUtils';
+import { useMeals } from './../../../hooks/useMeals';
+import { useNutritionAnalysis } from './../../../hooks/useNutritionAnalysis';
+import { getCurrentTimePeriod } from '../../../data/timePeriods';
 
+import LightBulbIcon from '@/assets/icons/icon-light-bulb.svg?react';
+import TestPage from '../../home/test/TestPage';
+
+const searchConfig = {
+  일간: 'daily',
+  주간: 'weekly',
+  월간: 'monthly',
+};
+
+const userId = 'yZxviIBudsaf8KYYhCCUWFpy3Ug1';
 export default function AiReportPage({
+  originDate,
   fullDate,
   activePeriod,
   setActivePeriod,
@@ -11,6 +25,13 @@ export default function AiReportPage({
   next,
   canMove,
 }) {
+  const parsedDate = parseDateString(originDate);
+  const newDate = new Date(parsedDate.year, parsedDate.month - 1, parsedDate.date);
+  const selectedDate = getTodayKey(newDate);
+
+  const currentTimePeriod = getCurrentTimePeriod(selectedDate);
+  const [searchType, setSearchType] = useState(searchConfig[activePeriod]);
+
   const onPrevPeriod = () => {
     prev();
   };
@@ -18,6 +39,26 @@ export default function AiReportPage({
   const onNextPeriod = () => {
     next();
   };
+
+  // 1. Firestore 에서 식단 가져오기
+  const {
+    data: meals,
+    isLoading: mealsLoading,
+    isError: mealsError,
+    error: mealsErrorMsg,
+    dataUpdatedAt,
+    status: mealsStatus,
+  } = useMeals(userId, selectedDate, searchType);
+
+  // 2. meals가 준비되면 AI 분석
+  const {
+    data: aiResult,
+    isLoading: aiLoading,
+    isError: aiError,
+    error: aiErrorMsg,
+    status,
+    isCached,
+  } = useNutritionAnalysis(meals, selectedDate, currentTimePeriod);
 
   return (
     <main className='flex flex-col gap-7.5'>
@@ -33,8 +74,32 @@ export default function AiReportPage({
         onPeriodChange={setActivePeriod}
       >
         <section className='flex flex-col gap-2.5 w-90 pt-5 pb-5 pr-5 pl-5 rounded-2xl text-white bg-[var(--color-primary)] text-center'>
-          <article className='flex flex-row items-center justify-center text-lg'><LightBulbIcon /> AI 코치의 조언</article>
-          <article className='text-xl'>주간 탄수화물이 다소 많습니다. 밥·빵 섭취를 줄여 보세요.</article>
+          <article className='flex flex-row items-center justify-center text-lg'>
+            <LightBulbIcon /> AI 코치의 조언
+          </article>
+          <article className='text-xl'>
+            <p className=''>
+              {mealsLoading && <span>식단 불러오는 중…</span>}
+              {mealsError && <span>식단 조회 실패: {mealsErrorMsg.message}</span>}
+              {aiLoading && <span>AI 결과 불러오는 중...</span>}
+              {aiError && <span>AI 조회 실패: {aiErrorMsg.message}</span>}
+
+              {/* 로딩/에러가 없을 때만 AI 결과 렌더링 */}
+              {!(mealsLoading || mealsError || aiLoading || aiError) &&
+                (aiResult?.text ? (
+                  aiResult.text
+                    .split('.')
+                    .filter(Boolean)
+                    .map((sentence, idx) => (
+                      <span key={idx} className='block mt-1 mb-2'>
+                        {sentence.trim()}.
+                      </span>
+                    ))
+                ) : (
+                  <span>아직 AI 코치의 분석 결과가 없습니다.</span>
+                ))}
+            </p>
+          </article>
         </section>
       </ChartArea>
     </main>

--- a/yum-yum/src/pages/report/pages/AiReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/AiReportPage.jsx
@@ -15,7 +15,7 @@ const searchConfig = {
   월간: 'monthly',
 };
 
-const userId = 'yZxviIBudsaf8KYYhCCUWFpy3Ug1';
+const userId = 'test-user';
 export default function AiReportPage({
   originDate,
   fullDate,

--- a/yum-yum/src/pages/report/pages/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/DietReportPage.jsx
@@ -12,10 +12,15 @@ import Carbohydrate from '@/assets/icons/icon-carbohydrate.svg?react';
 import Fat from '@/assets/icons/icon-fat.svg?react';
 import Protein from '@/assets/icons/icon-protein.svg?react';
 
-import { useMonthlyReportData, useWeeklyReportData } from '../../../hooks/useReportData';
-import { dataSummary, normalizeDataRange } from './../../../utils/reportDataParser';
+import {
+  useDailyReportData,
+  useMonthlyReportData,
+  useWeeklyReportData,
+} from '@/hooks/useReportData';
+import { dataSummary, normalizeDataRange } from '@/utils/reportDataParser';
+import { getAllMealsSorted } from './../../../utils/reportDataParser';
 
-const userId = 'yZxviIBudsaf8KYYhCCUWFpy3Ug1';
+const userId = 'test-user';
 export default function DietReportPage({
   originDate,
   fullDate,
@@ -25,8 +30,24 @@ export default function DietReportPage({
   next,
   canMove,
 }) {
-const { userData: weeklyUserData, weeklyData, isLoading: weeklyIsLoading, isError: weeklyIsError } = useWeeklyReportData(userId, originDate);
-const { userData: monthlyUserData, monthlyData, isLoading: monthlyIsLoading, isError: monthlyIsError } = useMonthlyReportData(userId, originDate);
+  const {
+    userData: dailyUserData,
+    dailyData,
+    isLoading: daliyIsLoading,
+    isError: daliyIsError,
+  } = useDailyReportData(userId, originDate);
+  const {
+    userData: weeklyUserData,
+    weeklyData,
+    isLoading: weeklyIsLoading,
+    isError: weeklyIsError,
+  } = useWeeklyReportData(userId, originDate);
+  const {
+    userData: monthlyUserData,
+    monthlyData,
+    isLoading: monthlyIsLoading,
+    isError: monthlyIsError,
+  } = useMonthlyReportData(userId, originDate);
   // 상세 정보 토글버튼
   const [activeDetailTab, setActiveDetailTab] = useState('영양 정보');
   const DetailTab = [{ name: '영양 정보' }, { name: '영양소 별 음식' }];
@@ -50,14 +71,20 @@ const { userData: monthlyUserData, monthlyData, isLoading: monthlyIsLoading, isE
 
   useEffect(() => {
     if (activePeriod === '일간') {
-      console.log('일간 데이터 호출');
+      setNutrient(
+        dataSummary(normalizeDataRange(dailyData?.mealData ?? [], originDate, activePeriod)),
+      );
     } else if (activePeriod === '주간') {
-
-      setNutrient(dataSummary(normalizeDataRange(weeklyData?.mealData ?? [], originDate, activePeriod)));
+      setNutrient(
+        dataSummary(normalizeDataRange(weeklyData?.mealData ?? [], originDate, activePeriod)),
+      );
     } else if (activePeriod === '월간') {
-      setNutrient(dataSummary(normalizeDataRange(monthlyData?.mealData ?? [], originDate, activePeriod)));
+      setNutrient(
+        dataSummary(normalizeDataRange(monthlyData?.mealData ?? [], originDate, activePeriod)),
+      );
+      // console.log(getAllMealsSorted(normalizeDataRange(monthlyData?.mealData ?? [], originDate, activePeriod)));
     }
-  }, [weeklyData, monthlyData, activePeriod]);
+  }, [dailyData, weeklyData, monthlyData, activePeriod]);
 
   const topChart = [
     {

--- a/yum-yum/src/pages/report/pages/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/DietReportPage.jsx
@@ -13,7 +13,7 @@ import Fat from '@/assets/icons/icon-fat.svg?react';
 import Protein from '@/assets/icons/icon-protein.svg?react';
 
 
-export default function DietReportPage({fullDate, activePeriod, setActivePeriod, prev, next, canMove}) {
+export default function DietReportPage({originDate, fullDate, activePeriod, setActivePeriod, prev, next, canMove}) {
 
   // 상세 정보 토글버튼
   const [activeDetailTab, setActiveDetailTab] = useState('영양 정보');

--- a/yum-yum/src/pages/report/pages/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/DietReportPage.jsx
@@ -82,7 +82,7 @@ export default function DietReportPage({
       setNutrient(
         dataSummary(normalizeDataRange(monthlyData?.mealData ?? [], originDate, activePeriod)),
       );
-      // console.log(getAllMealsSorted(normalizeDataRange(monthlyData?.mealData ?? [], originDate, activePeriod)));
+      console.log(getAllMealsSorted(normalizeDataRange(monthlyData?.mealData ?? [], originDate, activePeriod)));
     }
   }, [dailyData, weeklyData, monthlyData, activePeriod]);
 

--- a/yum-yum/src/pages/report/pages/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/DietReportPage.jsx
@@ -12,21 +12,34 @@ import Carbohydrate from '@/assets/icons/icon-carbohydrate.svg?react';
 import Fat from '@/assets/icons/icon-fat.svg?react';
 import Protein from '@/assets/icons/icon-protein.svg?react';
 
+import { useMonthlyReportData, useWeeklyReportData } from '../../../hooks/useReportData';
+import { dataSummary, normalizeDataRange } from './../../../utils/reportDataParser';
 
-export default function DietReportPage({originDate, fullDate, activePeriod, setActivePeriod, prev, next, canMove}) {
-
+const userId = 'yZxviIBudsaf8KYYhCCUWFpy3Ug1';
+export default function DietReportPage({
+  originDate,
+  fullDate,
+  activePeriod,
+  setActivePeriod,
+  prev,
+  next,
+  canMove,
+}) {
+const { userData: weeklyUserData, weeklyData, isLoading: weeklyIsLoading, isError: weeklyIsError } = useWeeklyReportData(userId, originDate);
+const { userData: monthlyUserData, monthlyData, isLoading: monthlyIsLoading, isError: monthlyIsError } = useMonthlyReportData(userId, originDate);
   // 상세 정보 토글버튼
   const [activeDetailTab, setActiveDetailTab] = useState('영양 정보');
   const DetailTab = [{ name: '영양 정보' }, { name: '영양소 별 음식' }];
 
+  const [nutrient, setNutrient] = useState({});
+
   const onPrevPeriod = () => {
     prev();
-  }
+  };
 
-  
   const onNextPeriod = () => {
     next();
-  }
+  };
 
   // 영양소별 음식 아이콘
   const nutritionIcon = {
@@ -35,28 +48,16 @@ export default function DietReportPage({originDate, fullDate, activePeriod, setA
     지방: <Fat />,
   };
 
-  const data = [
-    { name: '탄수화물', value: 400 },
-    { name: '단백질', value: 300 },
-    { name: '지방', value: 300 },
-  ];
+  useEffect(() => {
+    if (activePeriod === '일간') {
+      console.log('일간 데이터 호출');
+    } else if (activePeriod === '주간') {
 
-  const nutrient = {
-    kcal: 250,
-    carbs: 45,
-    sugar: 12,
-    sweetener: 2,
-    fiber: 8,
-    protein: 15,
-    fat: 8,
-    satFat: 3,
-    transFat: 0,
-    unsatFat: 5,
-    cholesterol: 25,
-    sodium: 480,
-    potassium: 320,
-    caffeine: 95,
-  };
+      setNutrient(dataSummary(normalizeDataRange(weeklyData?.mealData ?? [], originDate, activePeriod)));
+    } else if (activePeriod === '월간') {
+      setNutrient(dataSummary(normalizeDataRange(monthlyData?.mealData ?? [], originDate, activePeriod)));
+    }
+  }, [weeklyData, monthlyData, activePeriod]);
 
   const topChart = [
     {
@@ -109,7 +110,7 @@ export default function DietReportPage({originDate, fullDate, activePeriod, setA
         date={fullDate}
         period='일간'
         unit='Kcal'
-        value='768'
+        value={nutrient.totalCalories}
         activePeriod={activePeriod}
         prevDate={onPrevPeriod}
         nextDate={onNextPeriod}
@@ -117,7 +118,7 @@ export default function DietReportPage({originDate, fullDate, activePeriod, setA
         onPeriodChange={setActivePeriod}
       >
         {/* 탄단지 비율 차트 */}
-        <PieCharts data={data} />
+        <PieCharts data={nutrient} />
       </ChartArea>
 
       {/* 영양 정보 & 영양소별 음식 토글 버튼*/}
@@ -156,9 +157,9 @@ export default function DietReportPage({originDate, fullDate, activePeriod, setA
 
                 {/* 스택 차트 */}
                 <StackedCharts data={data} />
-              
+
                 {/* 음식 목록 */}
-                <NutritionFood foodData={data}/>
+                <NutritionFood foodData={data} />
               </React.Fragment>
             ))}
           </>

--- a/yum-yum/src/pages/report/pages/ReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/ReportPage.jsx
@@ -115,7 +115,7 @@ export default function ReportPage() {
           </BasicButton>
         ))}
       </nav>
-      <main>{CurrentComponent && <CurrentComponent fullDate={fullDate} activePeriod={activePeriod} setActivePeriod={setActivePeriod} 
+      <main>{CurrentComponent && <CurrentComponent originDate={date} fullDate={fullDate} activePeriod={activePeriod} setActivePeriod={setActivePeriod} 
       prev={handlePrevDate} next={handleNextDate} canMove={canMove}/>}</main>
     </div>
   );

--- a/yum-yum/src/pages/report/pages/WaterReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/WaterReportPage.jsx
@@ -4,6 +4,7 @@ import ChartArea from '../components/ChartArea';
 import WaterWeightInfo from '../components/WaterWeightInfo';
 
 export default function WaterReportPage({
+  originDate,
   fullDate,
   activePeriod,
   setActivePeriod,

--- a/yum-yum/src/pages/report/pages/WeightReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/WeightReportPage.jsx
@@ -4,6 +4,7 @@ import LineCharts from '../charts/LineCharts';
 import WaterWeightInfo from '../components/WaterWeightInfo';
 
 export default function WeightReportPage({
+  originDate,
   fullDate,
   activePeriod,
   setActivePeriod,

--- a/yum-yum/src/services/dailyDataApi.js
+++ b/yum-yum/src/services/dailyDataApi.js
@@ -3,6 +3,7 @@ import { firestore } from './firebase';
 
 export async function getDailyData(userId, selectedDate) {
   const date = new Date(selectedDate).toISOString().split('T')[0];
+  
   try {
     // 컬렉션 참조 생성
     const waterRef = collection(firestore, 'users', userId, 'water');

--- a/yum-yum/src/services/monthlyDataApi.js
+++ b/yum-yum/src/services/monthlyDataApi.js
@@ -1,0 +1,51 @@
+import { collection, query, where, orderBy, getDocs, Timestamp } from 'firebase/firestore';
+import { firestore } from './../services/firebase';
+import { getEndDateOfMonth, parseDateString, getStartDateOfMonth } from '../utils/dateUtils';
+
+export const getMonthlyData = async (userId, startDay, endDay) => {
+  try {
+    // 컬렉션 참조 생성
+    const mealRef = collection(firestore, 'users', userId, 'meal');
+    const waterRef = collection(firestore, 'users', userId, 'water');
+
+    const mealQuery = query(
+      mealRef,
+      where('createdAt', '>=', Timestamp.fromDate(startDay)),
+      where('createdAt', '<', Timestamp.fromDate(endDay)),
+      orderBy('createdAt'),
+    );
+
+    const waterQuery = query(
+      waterRef,
+      where('createdAt', '>=', Timestamp.fromDate(startDay)),
+      where('createdAt', '<', Timestamp.fromDate(endDay)),
+      orderBy('createdAt'),
+    );
+
+    const [waterSnap, mealSnap] = await Promise.all([getDocs(waterQuery), getDocs(mealQuery)]);
+
+    const waterData = waterSnap.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
+
+    const mealData = mealSnap.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
+
+    return {
+      success: true,
+      data: {
+        waterData: waterData,
+        mealData: mealData,
+      },
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};

--- a/yum-yum/src/services/monthlyDataApi.js
+++ b/yum-yum/src/services/monthlyDataApi.js
@@ -1,8 +1,12 @@
 import { collection, query, where, orderBy, getDocs, Timestamp } from 'firebase/firestore';
 import { firestore } from './../services/firebase';
-import { getEndDateOfMonth, parseDateString, getStartDateOfMonth } from '../utils/dateUtils';
 
 export const getMonthlyData = async (userId, startDay, endDay) => {
+  const startOfDay = startDay.toISOString().split('T')[0];
+  const endOfDay = endDay.toISOString().split('T')[0];
+
+  console.log("여기", startOfDay)
+
   try {
     // 컬렉션 참조 생성
     const mealRef = collection(firestore, 'users', userId, 'meal');
@@ -10,18 +14,17 @@ export const getMonthlyData = async (userId, startDay, endDay) => {
 
     const mealQuery = query(
       mealRef,
-      where('createdAt', '>=', Timestamp.fromDate(startDay)),
-      where('createdAt', '<', Timestamp.fromDate(endDay)),
-      orderBy('createdAt'),
+      where('date', '>=', startOfDay),
+      where('date', '<', endOfDay),
+      orderBy('date'),
     );
 
     const waterQuery = query(
       waterRef,
-      where('createdAt', '>=', Timestamp.fromDate(startDay)),
-      where('createdAt', '<', Timestamp.fromDate(endDay)),
-      orderBy('createdAt'),
+      where('date', '>=', startOfDay),
+      where('date', '<', endOfDay),
+      orderBy('date'),
     );
-
     const [waterSnap, mealSnap] = await Promise.all([getDocs(waterQuery), getDocs(mealQuery)]);
 
     const waterData = waterSnap.docs.map((doc) => ({
@@ -34,6 +37,9 @@ export const getMonthlyData = async (userId, startDay, endDay) => {
       ...doc.data(),
     }));
 
+    
+    console.log(mealData)
+    
     return {
       success: true,
       data: {

--- a/yum-yum/src/services/weeklyDataApi.js
+++ b/yum-yum/src/services/weeklyDataApi.js
@@ -2,6 +2,9 @@ import { collection, query, where, orderBy, getDocs, Timestamp } from 'firebase/
 import { firestore } from './../services/firebase';
 
 export const getWeeklyData = async (userId, startDay, endDay) => {
+  const startOfDay = startDay.toISOString().split('T')[0];
+  const endOfDay = endDay.toISOString().split('T')[0];
+
   try {
     // 컬렉션 참조 생성
     const mealRef = collection(firestore, 'users', userId, 'meal');
@@ -9,16 +12,16 @@ export const getWeeklyData = async (userId, startDay, endDay) => {
 
     const mealQuery = query(
       mealRef,
-      where('createdAt', '>=', Timestamp.fromDate(startDay)),
-      where('createdAt', '<', Timestamp.fromDate(endDay)),
-      orderBy('createdAt'),
+      where('date', '>=', startOfDay),
+      where('date', '<', endOfDay),
+      orderBy('date'),
     );
 
     const waterQuery = query(
       waterRef,
-      where('createdAt', '>=', Timestamp.fromDate(startDay)),
-      where('createdAt', '<', Timestamp.fromDate(endDay)),
-      orderBy('createdAt'),
+      where('date', '>=', startOfDay),
+      where('date', '<', endOfDay),
+      orderBy('date'),
     );
 
     const [waterSnap, mealSnap] = await Promise.all([getDocs(waterQuery), getDocs(mealQuery)]);

--- a/yum-yum/src/services/weeklyDataApi.js
+++ b/yum-yum/src/services/weeklyDataApi.js
@@ -1,0 +1,50 @@
+import { collection, query, where, orderBy, getDocs, Timestamp } from 'firebase/firestore';
+import { firestore } from './../services/firebase';
+
+export const getWeeklyData = async (userId, startDay, endDay) => {
+  try {
+    // 컬렉션 참조 생성
+    const mealRef = collection(firestore, 'users', userId, 'meal');
+    const waterRef = collection(firestore, 'users', userId, 'water');
+
+    const mealQuery = query(
+      mealRef,
+      where('createdAt', '>=', Timestamp.fromDate(startDay)),
+      where('createdAt', '<', Timestamp.fromDate(endDay)),
+      orderBy('createdAt'),
+    );
+
+    const waterQuery = query(
+      waterRef,
+      where('createdAt', '>=', Timestamp.fromDate(startDay)),
+      where('createdAt', '<', Timestamp.fromDate(endDay)),
+      orderBy('createdAt'),
+    );
+
+    const [waterSnap, mealSnap] = await Promise.all([getDocs(waterQuery), getDocs(mealQuery)]);
+
+    const waterData = waterSnap.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
+
+    const mealData = mealSnap.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
+
+    return {
+      success: true,
+      data: {
+        waterData: waterData,
+        mealData: mealData,
+      },
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};

--- a/yum-yum/src/utils/calorieCalculator.js
+++ b/yum-yum/src/utils/calorieCalculator.js
@@ -90,8 +90,8 @@ export function calculateNutrientRatio(carbs = 0, proteins = 0, fats = 0) {
   const totalCalories = carbs * 4 + proteins * 4 + fats * 9;
 
   return {
-    carbsRatio: Math.round((carbs * 4) / totalCalories) * 100,
-    proteinsRatio : Math.round((proteins * 4) / totalCalories) * 100,
-    fatsRatio : Math.round((fats * 9) / totalCalories) * 100,
+    carbsRatio: Math.round((carbs * 4) / totalCalories * 100),
+    proteinsRatio : Math.round((proteins * 4) / totalCalories * 100),
+    fatsRatio : Math.round((fats * 9) / totalCalories * 100),
   }
 }

--- a/yum-yum/src/utils/calorieCalculator.js
+++ b/yum-yum/src/utils/calorieCalculator.js
@@ -83,3 +83,15 @@ export function calculateWaterIntake(age, gender) {
   // 성인 (19세 이상)
   return gender === 'male' ? 2600 : 2100;
 }
+
+// 칼로리 대비 각 영양소 비율 계산
+export function calculateNutrientRatio(carbs = 0, proteins = 0, fats = 0) {
+
+  const totalCalories = carbs * 4 + proteins * 4 + fats * 9;
+
+  return {
+    carbsRatio: Math.round((carbs * 4) / totalCalories) * 100,
+    proteinsRatio : Math.round((proteins * 4) / totalCalories) * 100,
+    fatsRatio : Math.round((fats * 9) / totalCalories) * 100,
+  }
+}

--- a/yum-yum/src/utils/dateUtils.js
+++ b/yum-yum/src/utils/dateUtils.js
@@ -69,6 +69,20 @@ export function getEndDateOfWeek(date) {
   return dateFormatting(endOfWeek(newDate));
 }
 
+// 이번달 시작 날짜
+export function getStartDateOfMonth(date) {
+  const newDate = parseDate(date);
+
+  return dateFormatting(startOfMonth(newDate));
+}
+
+// 이번달 종료 날짜
+export function getEndDateOfMonth(date) {
+  const newDate = parseDate(date);
+
+  return dateFormatting(endOfMonth(newDate));
+}
+
 // ---
 
 // 전날
@@ -126,6 +140,7 @@ export function getNextMonth(date) {
 // 년 월 일 추출 - 정규식 이용
 export const parseDateString = (dateString) => {
   const regex = /(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일/;
+  
   const match = dateString.match(regex);
 
   const [full, year, month, date] = match;

--- a/yum-yum/src/utils/reportDataParser.js
+++ b/yum-yum/src/utils/reportDataParser.js
@@ -13,7 +13,10 @@ export function normalizeDataRange(rawData, selectedDate, period) {
   let startDay;
   let endDay;
 
-  if (period === '주간') {
+  if (period === '일간') {
+    startDay = parseDateString(selectedDate);
+    endDay = parseDateString(selectedDate);
+  } else if (period === '주간') {
     startDay = parseDateString(getStartDateOfWeek(selectedDate));
     endDay = parseDateString(getEndDateOfWeek(selectedDate));
   } else if (period === '월간') {
@@ -30,7 +33,7 @@ export function normalizeDataRange(rawData, selectedDate, period) {
   // rawData를 Map으로 변환해서 빠른 조회 가능
   const dataMap = new Map(rawData.map((d) => [d.date, d]));
 
-  console.log(dataMap);
+  console.log(start, end, dataMap);
 
   // 모든 날짜를 돌면서 없는 날은 0으로 채움
   return allDays.map((day) => {
@@ -93,4 +96,23 @@ export const dataSummary = (allFoods) => {
       0,
     ), // 카페인
   };
+};
+
+export const getAllMealsSorted = (data, nutrientKey = 'carbs') => {
+  console.log('여기 : ', data);
+
+  return data
+    .reduce((allMeals, dayData) => {
+      if (dayData.value !== 0) {
+        const mealsData = dayData.value.meals.map((meal) => {
+          console.log(meal);
+          return meal;
+        });
+
+        return [...allMeals, ...mealsData];
+      }
+
+      return allMeals;
+    }, [])
+    .sort((a, b) => toNum(b[nutrientKey]) - toNum(a[nutrientKey]));
 };

--- a/yum-yum/src/utils/reportDataParser.js
+++ b/yum-yum/src/utils/reportDataParser.js
@@ -1,16 +1,96 @@
 // utils/normalizeData.ts
-import { eachDayOfInterval, format } from "date-fns";
+import { eachDayOfInterval, format } from 'date-fns';
+import {
+  getEndDateOfMonth,
+  getEndDateOfWeek,
+  getStartDateOfMonth,
+  getStartDateOfWeek,
+  parseDateString,
+} from './dateUtils';
+import { toNum } from './NutrientNumber';
 
-export function normalizeDataRange(rawData, start, end) {
+export function normalizeDataRange(rawData, selectedDate, period) {
+  let startDay;
+  let endDay;
+
+  if (period === '주간') {
+    startDay = parseDateString(getStartDateOfWeek(selectedDate));
+    endDay = parseDateString(getEndDateOfWeek(selectedDate));
+  } else if (period === '월간') {
+    startDay = parseDateString(getStartDateOfMonth(selectedDate));
+    endDay = parseDateString(getEndDateOfMonth(selectedDate));
+  }
+
+  const start = new Date(startDay.year, startDay.month - 1, startDay.date);
+  const end = new Date(endDay.year, endDay.month - 1, endDay.date);
+
   // 기준의 모든 날짜만큼 생성
   const allDays = eachDayOfInterval({ start, end });
 
   // rawData를 Map으로 변환해서 빠른 조회 가능
-  const dataMap = new Map(rawData.map((d) => [d.date, d.value]));
+  const dataMap = new Map(rawData.map((d) => [d.date, d]));
+
+  console.log(dataMap);
 
   // 모든 날짜를 돌면서 없는 날은 0으로 채움
   return allDays.map((day) => {
-    const key = format(day, "yyyy-MM-dd");
+    const key = format(day, 'yyyy-MM-dd');
     return { date: key, value: dataMap.get(key) ?? 0 };
   });
 }
+
+// 특정 기간의 값을 가공
+export const dataSummary = (allFoods) => {
+  // 유효한 값이 있는 경우의 날짜를 체크
+  const length = allFoods.reduce((result, food) => {
+    const value = food.value;
+
+    if (typeof value === 'object' && value !== null) {
+      result++;
+    }
+    return result;
+  }, 0);
+
+  console.log(allFoods);
+
+  return {
+    totalCalories:
+      length > 0
+        ? allFoods.reduce((sum, f) => sum + toNum(f.value?.dailySummary?.totalCalories), 0) / length
+        : 0, // 칼로리
+    totalCarbs: allFoods.reduce((sum, f) => sum + toNum(f.value?.dailySummary?.totalCarbs), 0), // 탄수화물
+    totalProtein: allFoods.reduce((sum, f) => sum + toNum(f.value?.dailySummary?.totalProtein), 0), // 단백질
+    totalFat: allFoods.reduce((sum, f) => sum + toNum(f.value?.dailySummary?.totalFat), 0), // 지방
+    totalSugar: allFoods.reduce((sum, f) => sum + toNum(f.value?.dailySummary?.totalSugar), 0), // 당류
+    totalSweetener: allFoods.reduce(
+      (sum, f) => sum + toNum(f.value?.dailySummary?.totalSweetener),
+      0,
+    ), // 대체 감미료
+    totalFiber: allFoods.reduce((sum, f) => sum + toNum(f.value?.dailySummary?.totalFiber), 0), // 식이섬유
+    totalSaturatedFat: allFoods.reduce(
+      (sum, f) => sum + toNum(f.value?.dailySummary?.totalSaturatedFat),
+      0,
+    ), // 포화지방
+    totalTransFat: allFoods.reduce(
+      (sum, f) => sum + toNum(f.value?.dailySummary?.totalTransFat),
+      0,
+    ), // 트랜스지방
+    totalUnsaturatedFat: allFoods.reduce(
+      (sum, f) => sum + toNum(f.value?.dailySummary?.totalUnsaturatedFat),
+      0,
+    ), // 불포화지방
+    totalCholesterol: allFoods.reduce(
+      (sum, f) => sum + toNum(f.value?.dailySummary?.totalCholesterol),
+      0,
+    ), // 콜레스테롤
+    totalSodium: allFoods.reduce((sum, f) => sum + toNum(f.value?.dailySummary?.totalSodium), 0), // 나트륨
+    totalPotassium: allFoods.reduce(
+      (sum, f) => sum + toNum(f.value?.dailySummary?.totalPotassium),
+      0,
+    ), // 칼륨
+    totalCaffeine: allFoods.reduce(
+      (sum, f) => sum + toNum(f.value?.dailySummary?.totalCaffeine),
+      0,
+    ), // 카페인
+  };
+};


### PR DESCRIPTION
## 📝 작업 개요
- 식단 리포트 데이터 연동

## 🔨 작업 내용
- 식단 리포트 차트 및 영양 정보 연동
- 차트 비율 계산식 변경
- 칼로리 대비 영양소 비율 식 오류 수정

## ✅ 테스트 방법
- 식단 리포트 날짜 선택 및 일간/주간/월간 클릭
