### PR TITLE
[feat] 페이지 이동 시 스크롤 최상단으로 이동하는 기능 추가

### DIFF
--- a/yum-yum/src/App.jsx
+++ b/yum-yum/src/App.jsx
@@ -18,6 +18,7 @@ import CustomEntryForm from './pages/meal/page/CustomEntryForm';
 import TotalMeal from './pages/meal/page/TotalMeal';
 import TestPage from './pages/home/test/TestPage';
 import FoodSearchResultsPage from './pages/meal/page/FoodSearchResults';
+import ScrollToTop from './components/ScrollToTop';
 
 const router = createBrowserRouter([
   {
@@ -27,6 +28,7 @@ const router = createBrowserRouter([
       {
         element: (
           <RequireAuth>
+            <ScrollToTop />
             <Layout />
           </RequireAuth>
         ),
@@ -46,6 +48,7 @@ const router = createBrowserRouter([
       {
         element: (
           <RequireGuest>
+            <ScrollToTop />
             <SimpleLayout />
           </RequireGuest>
         ),

--- a/yum-yum/src/components/ScrollToTop.jsx
+++ b/yum-yum/src/components/ScrollToTop.jsx
@@ -1,0 +1,11 @@
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return null;
+}


### PR DESCRIPTION
## 📝 작업 개요
- 페이지 이동 시 스크롤이 유지되어 최상단으로 이동하는 기능 추가

## 🔨 작업 내용
- ScrollToTop.jsx 컴포넌트 생성
- App.jsx router에 컴포넌트 추가

## ✅ 테스트 방법

## 📎 관련 이슈

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)