### PR TITLE
[feat] 영양소 소수점 첫째자리 고정

### DIFF
--- a/yum-yum/src/App.jsx
+++ b/yum-yum/src/App.jsx
@@ -18,6 +18,7 @@ import CustomEntryForm from './pages/meal/page/CustomEntryForm';
 import TotalMeal from './pages/meal/page/TotalMeal';
 import TestPage from './pages/home/test/TestPage';
 import FoodSearchResultsPage from './pages/meal/page/FoodSearchResults';
+import ScrollToTop from './components/ScrollToTop';
 
 const router = createBrowserRouter([
   {
@@ -27,6 +28,7 @@ const router = createBrowserRouter([
       {
         element: (
           <RequireAuth>
+            <ScrollToTop />
             <Layout />
           </RequireAuth>
         ),
@@ -46,6 +48,7 @@ const router = createBrowserRouter([
       {
         element: (
           <RequireGuest>
+            <ScrollToTop />
             <SimpleLayout />
           </RequireGuest>
         ),

--- a/yum-yum/src/components/ScrollToTop.jsx
+++ b/yum-yum/src/components/ScrollToTop.jsx
@@ -1,0 +1,11 @@
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return null;
+}

--- a/yum-yum/src/pages/meal/component/TotalBarChart.jsx
+++ b/yum-yum/src/pages/meal/component/TotalBarChart.jsx
@@ -9,9 +9,9 @@ export default function TotalBarChart() {
   const foods = Object.values(selectedFoods); // 선택된 음식
 
   // 총 탄수화물, 총 단백질, 총 지방, 총 합
-  const totalCarbs = foods.reduce((sum, f) => sum + toNum(f.nutrient?.carbs), 0);
-  const totalProtein = foods.reduce((sum, f) => sum + toNum(f.nutrient?.protein), 0);
-  const totalFat = foods.reduce((sum, f) => sum + toNum(f.nutrient?.fat), 0);
+  const totalCarbs = roundTo1(foods.reduce((sum, f) => sum + toNum(f.nutrient?.carbs), 0));
+  const totalProtein = roundTo1(foods.reduce((sum, f) => sum + toNum(f.nutrient?.protein), 0));
+  const totalFat = roundTo1(foods.reduce((sum, f) => sum + toNum(f.nutrient?.fat), 0));
   const totalNutrient = totalCarbs + totalProtein + totalFat;
 
   // 라벨에 보여지는 퍼센트


### PR DESCRIPTION
## 📝 작업 개요
- 그래프 영양소 소수점 첫째자리 고정

## 🔨 작업 내용
- 영양소 합계에 소수점 첫째자리까지 반올림하는 roundTo1 유틸 함수 추가

## ✅ 테스트 방법
<img width="490" height="903" alt="20250917_111617" src="https://github.com/user-attachments/assets/39f86900-45eb-43f8-b3e3-d5e34b9e9943" />


## 📎 관련 이슈
- Close #68 

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)