### PR TITLE
[feat] 음식 검색 시, 검색 데이터 캐싱 처리

### DIFF
--- a/yum-yum/src/hooks/useMainPageData.js
+++ b/yum-yum/src/hooks/useMainPageData.js
@@ -4,15 +4,6 @@ import { getUserData } from '../services/userApi';
 import { getDailyData } from '../services/dailyDataApi';
 
 export const usePageData = (userId, selectedDate) => {
-  // 사용자 데이터 불러오기
-  const userQuery = useQuery({
-    queryKey: ['user', userId],
-    queryFn: () => getUserData(userId),
-    select: (response) => response.data,
-    staleTime: 10 * 60 * 1000, // 10분
-    enabled: !!userId, // userId가 있을 때만 실행
-  });
-
   // 선택된 날짜의 물, 식사 데이터
   const dailyDataQuery = useQuery({
     queryKey: ['dailyData', userId, selectedDate],
@@ -27,16 +18,9 @@ export const usePageData = (userId, selectedDate) => {
   const refetchDaily = () => dailyDataQuery.refetch();
 
   return {
-    // 사용자 데이터
-    userData: userQuery.data,
-    userLoading: userQuery.isLoading,
-
     // 일일 데이터
     dailyData: dailyDataQuery.data,
     dailyLoading: dailyDataQuery.isLoading,
-
-    // 전체 로딩 상태
-    isLoading: userQuery.isLoading || dailyDataQuery.isLoading,
 
     // 수동 갱신 (일일 데이터)
     refetchDaily,

--- a/yum-yum/src/hooks/useSearchFoodData.js
+++ b/yum-yum/src/hooks/useSearchFoodData.js
@@ -1,0 +1,20 @@
+// 음식 검색한 데이터 캐싱
+
+import { useQuery } from '@tanstack/react-query';
+import { fetchNutritionData } from '../services/searchFoodApi';
+
+export const useSearchFoodData = (searchKeyword) => {
+  const searchFoodDataQuery = useQuery({
+    queryKey: ['searchFoodData', searchKeyword],
+    queryFn: () => fetchNutritionData(searchKeyword),
+    staleTime: 60 * 60 * 1000,
+    enabled: !!searchKeyword,
+  });
+
+  return {
+    searchData: searchFoodDataQuery.data,
+    isLoading: searchFoodDataQuery.isLoading,
+    isError: searchFoodDataQuery.isError,
+    refetch: searchFoodDataQuery.refetch,
+  };
+};

--- a/yum-yum/src/hooks/useUser.js
+++ b/yum-yum/src/hooks/useUser.js
@@ -1,0 +1,19 @@
+// 사용자 데이터 쿼리 훅
+import { useQuery } from '@tanstack/react-query';
+import { getUserData } from '../services/userApi';
+
+export const useUserData = (userId, selectedDate) => {
+  // 사용자 데이터 불러오기
+  const userQuery = useQuery({
+    queryKey: ['user', userId],
+    queryFn: () => getUserData(userId),
+    select: (response) => response.data,
+    staleTime: 10 * 60 * 1000, // 10분
+    enabled: !!userId, // userId가 있을 때만 실행
+  });
+
+  return {
+    userData: userQuery.data,
+    userLoading: userQuery.isLoading,
+  };
+};

--- a/yum-yum/src/pages/home/HomePage.jsx
+++ b/yum-yum/src/pages/home/HomePage.jsx
@@ -9,7 +9,7 @@ import { ko } from 'date-fns/locale';
 import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
-
+// 컴포넌트
 import DateHeader from '@/components/common/DateHeader';
 import OnBoarding from '@/components/common/OnBoarding';
 import Modal from '@/components/Modal';
@@ -22,8 +22,11 @@ import CalorieHeader from './card/calorie/CalorieHeader';
 import CalorieMessage from './card/calorie/CalorieMessage';
 import CalorieNutrition from './card/calorie/CalorieNutrition';
 import WeightInput from './modal/WeightInput';
+// 훅
 import { useWeight } from '../../hooks/useWeight';
 import { usePageData } from '../../hooks/useMainPageData';
+import { useUserData } from '../../hooks/useUser';
+// 스토어
 import { useHomeStore } from '../../stores/useHomeStore';
 import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
 
@@ -48,10 +51,11 @@ export default function HomePage() {
     goalWeight,
     setDailyData,
     waterData,
-    mealData,
+    mealData, // 필요한 부분 파싱된 데이터
   } = useHomeStore();
   const { saveWeightMutation } = useWeight(userId, selectedDate);
-  const { userData, dailyData, isLoading, isError } = usePageData(userId, selectedDate);
+  const { dailyData, dailyLoading } = usePageData(userId, selectedDate);
+  const { userData } = useUserData(userId, selectedDate);
   const { clearFoods, addFood } = useSelectedFoodsStore();
 
   const {

--- a/yum-yum/src/pages/meal/page/FoodSearchResults.jsx
+++ b/yum-yum/src/pages/meal/page/FoodSearchResults.jsx
@@ -7,7 +7,7 @@ import FoodList from '../component/FoodList';
 import MealHeader from '../component/MealHeader';
 import { useSearchFoodStore } from '../../../stores/useSearchFoodStore';
 import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
-import { fetchNutritionData } from '../../../services/searchFoodApi';
+import { useSearchFoodData } from '../../../hooks/useSearchFoodData';
 
 export default function FoodSearchResultsPage() {
   const location = useLocation();
@@ -16,18 +16,17 @@ export default function FoodSearchResultsPage() {
   const date = location.state?.date; // 추가 타입
   const { searchFoodResults: foodItems, setSearchFoodResults } = useSearchFoodStore();
   const { selectedFoods, clearFoods } = useSelectedFoodsStore();
-
+  const { searchData, isLoading, isError, refetch } = useSearchFoodData(searchItem);
   const [searchInputValue, setSearchInputValue] = useState(searchItem || '');
   const navigate = useNavigate();
 
   // 음식 검색
   useEffect(() => {
-    // 검색 로직 추가
-    if (searchItem) {
-      // console.log('검색 실행:', searchItem);
-      searchFood(searchItem);
+    if (searchData) {
+      console.log('검색결과:', searchData);
+      setSearchFoodResults(searchData);
     }
-  }, [searchItem]);
+  }, [searchData]);
 
   // 헤더 입력값
   const onSearchChange = (e) => {
@@ -49,13 +48,6 @@ export default function FoodSearchResultsPage() {
     navigate(`/meal/${type}/total`, {
       state: { date },
     });
-  };
-
-  // 음식 검색 API 실행 함수
-  const searchFood = async (searchItem) => {
-    const foods = await fetchNutritionData(searchItem);
-    // console.log('파싱된 음식 데이터:', foods);
-    setSearchFoodResults(foods);
   };
 
   return (


### PR DESCRIPTION
## 📝 작업 개요
- 공공데이터 API 호출 회수를 줄이기 위한 캐싱 처리

## 🔨 작업 내용
- 음식 검색 시, 검색 데이터 캐싱 처리
- `searchFoodDataQuery` 추가하여 `RTK → fetch` 순으로 진행

## ✅ 테스트 방법
- 음식 검색을 할 때, 개발자 도구 → network 탭 오픈
- 음식 예를들어 김치볶음밥) 검색 후 다시 김치볶음밥 검색 시, api가 호출되는지 확인
- 혹은 김치볶음밥 검색 후, 참치마요덥밥 검색하여 API가 두 번 불러오는거 확인 후 다시 김치볶음밥 검색 후 API 호출이 늘어나는지 확인

## 📎 관련 이슈