### PR TITLE
[fix] 음식 선택 페이지 새로고침 시 데이터 유지 처리

### DIFF
--- a/yum-yum/src/pages/meal/MealPage.jsx
+++ b/yum-yum/src/pages/meal/MealPage.jsx
@@ -7,10 +7,9 @@ import CustomEntry from './page/CustomEntry';
 import MealHeader from './component/MealHeader';
 import MealTabs from './component/MealTabs';
 import BasicButton from '@/components/button/BasicButton';
-import FoodSearchResultsPage from './page/FoodSearchResults';
 
 const tabItem = [
-  { id: 'frequent', label: '자주 먹은 음식' },
+  { id: 'frequent', label: '최근 먹은 음식' },
   { id: 'custom', label: '직접 등록' },
 ];
 
@@ -77,56 +76,3 @@ export default function MealPage() {
     </div>
   );
 }
-
-// pages/Meal/MealPage.jsx
-// import React, { useState } from 'react';
-// import { fetchMfds } from '../../services/mfds';
-// import MealHeader from './component/MealHeader';
-// import SearchList from './page/SearchList';
-// import { useNavigate } from 'react-router-dom';
-
-// export default function MealPage() {
-//   const [searchInputValue, setSearchInputValue] = useState('');
-//   const [items, setItems] = useState([]); // ✅ 결과 상태
-//   const [loading, setLoading] = useState(false);
-//   const [errMsg, setErrMsg] = useState('');
-//   const navigate = useNavigate();
-
-//   const onSearchChange = (e) => setSearchInputValue(e.target.value);
-
-//   const handleSearchSubmit = async () => {
-//     const q = searchInputValue.trim();
-//     if (!q) return;
-//     setLoading(true);
-//     setErrMsg('');
-//     try {
-//       const data = await fetchMfds(q); // ✅ 검색어 전달
-//       setItems(data); // ✅ 결과 반영
-//       console.log('[MealPage] items=', data.length);
-//     } catch (e) {
-//       console.error(e);
-//       setErrMsg(e?.message || '요청 실패');
-//     } finally {
-//       setLoading(false);
-//     }
-//   };
-
-//   const handleRecord = () => navigate('/meal/total');
-
-//   return (
-//     <div>
-//       <MealHeader
-//         variant='search'
-//         value={searchInputValue}
-//         onChange={onSearchChange}
-//         handleSearchSubmit={handleSearchSubmit}
-//       />
-
-//       {loading && <div className='px-[20px] text-gray-600'>불러오는 중…</div>}
-//       {errMsg && <div className='px-[20px] text-red-600'>에러: {errMsg}</div>}
-
-//       {/* ✅ 결과 내려주기 */}
-//       <SearchList items={items} />
-//     </div>
-//   );
-// }

--- a/yum-yum/src/pages/meal/page/FrequentlyEatenFood.jsx
+++ b/yum-yum/src/pages/meal/page/FrequentlyEatenFood.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getFrequentFoods } from '@/services/FrequentFoodsApi';
+import { getRecentFoods } from '@/services/FrequentFoodsApi';
 // 컴포넌트
 import EmptyState from '@/components/EmptyState';
 import FoodList from '../component/FoodList';
@@ -12,7 +12,7 @@ export default function FrequentlyEatenFood({ selectedIds, onToggleSelect }) {
   useEffect(() => {
     const fetchFoods = async () => {
       try {
-        const data = await getFrequentFoods(mockUser.uid);
+        const data = await getRecentFoods(mockUser.uid);
         setFoodItems(data);
       } catch (error) {
         console.error('불러오기 실패:', error);

--- a/yum-yum/src/pages/meal/page/TotalMeal.jsx
+++ b/yum-yum/src/pages/meal/page/TotalMeal.jsx
@@ -11,6 +11,7 @@ import MealHeader from '../component/MealHeader';
 import FoodList from '../component/FoodList';
 import BasicButton from '@/components/button/BasicButton';
 import TotalBarChart from '../component/TotalBarChart';
+import { Timestamp } from 'firebase/firestore';
 
 export default function TotalMeal({ defaultDate = new Date(), dateFormat = 'MM월 dd일' }) {
   const { selectedFoods, deleteFood, clearFoods } = useSelectedFoodsStore();
@@ -57,7 +58,7 @@ export default function TotalMeal({ defaultDate = new Date(), dateFormat = 'MM�
         makerName: f.makerName ?? '',
         foodSize: f.foodSize ?? 0,
         foodUnit: f.foodUnit ?? 'g',
-
+        createdAt: Timestamp.now(),
         nutrient: {
           kcal: toNum(f.nutrient?.kcal),
           carbs: toNum(f.nutrient?.carbs),

--- a/yum-yum/src/services/FrequentFoodsApi.js
+++ b/yum-yum/src/services/FrequentFoodsApi.js
@@ -1,19 +1,30 @@
-import { collection, getDocs } from 'firebase/firestore';
+import { collection, getDocs, orderBy, query, where } from 'firebase/firestore';
 import { firestore } from './firebase';
 import { toNum } from '@/utils/NutrientNumber';
+import { format, subDays } from 'date-fns';
 
-// 자주 먹은 음식 조회
-export const getFrequentFoods = async () => {
+// 최근 3일 먹은 음식 조회
+export const getRecentFoods = async () => {
   try {
+    const today = new Date(); // 오늘 날짜
+    const fiveDaysAgo = subDays(today, 5); // 5일전
+    const startDate = format(fiveDaysAgo, 'yyyy-MM-dd');
+
     // const mealCol = collection(firestore, 'users', useId, 'meal');
     const mealCol = collection(firestore, 'users', 'test-user', 'meal');
-    const snapshot = await getDocs(mealCol);
 
-    const foodCount = {};
+    const q = query(mealCol, where('date', '>=', startDate), orderBy('date', 'desc'));
+
+    const snapshot = await getDocs(q);
+
+    const foods = [];
 
     // meal
     snapshot.forEach((doc) => {
       const data = doc.data();
+      if (!data.meals) return;
+
+      const docDate = data.date;
 
       // meals 객체
       Object.values(data.meals).forEach((mealArray) => {
@@ -21,43 +32,52 @@ export const getFrequentFoods = async () => {
         mealArray.forEach((f) => {
           if (!f.foodName) return;
 
-          // 없으면 객체 전체 저장, count+1
-          if (!foodCount[f.id]) {
-            foodCount[f.id] = {
-              id: f.id,
-              foodName: f.foodName ?? '',
-              makerName: f.makerName ?? '',
-              foodSize: f.foodSize ?? 0,
-              foodUnit: f.foodUnit ?? 'g',
-
-              nutrient: {
-                kcal: f.nutrient?.kcal,
-                carbs: toNum(f.nutrient?.carbs),
-                protein: toNum(f.nutrient?.protein),
-                fat: toNum(f.nutrient?.fat),
-                sugar: toNum(f.nutrient?.sugar),
-                sweetener: toNum(f.nutrient?.sweetener),
-                fiber: toNum(f.nutrient?.fiber),
-                satFat: toNum(f.nutrient?.satFat),
-                transFat: toNum(f.nutrient?.transFat),
-                unsatFat: toNum(f.nutrient?.unsatFat),
-                cholesterol: toNum(f.nutrient?.cholesterol),
-                sodium: toNum(f.nutrient?.sodium),
-                potassium: toNum(f.nutrient?.potassium),
-                caffeine: toNum(f.nutrient?.caffeine),
-              },
-              count: 0,
-            };
-          }
-          // 있으면 count+1
-          foodCount[f.id].count += 1;
+          foods.push({
+            id: f.id,
+            foodName: f.foodName ?? '',
+            makerName: f.makerName ?? '',
+            foodSize: f.foodSize ?? 0,
+            foodUnit: f.foodUnit ?? 'g',
+            date: docDate,
+            createdAt: f.createdAt ?? data.createdAt,
+            nutrient: {
+              kcal: f.nutrient?.kcal,
+              carbs: toNum(f.nutrient?.carbs),
+              protein: toNum(f.nutrient?.protein),
+              fat: toNum(f.nutrient?.fat),
+              sugar: toNum(f.nutrient?.sugar),
+              sweetener: toNum(f.nutrient?.sweetener),
+              fiber: toNum(f.nutrient?.fiber),
+              satFat: toNum(f.nutrient?.satFat),
+              transFat: toNum(f.nutrient?.transFat),
+              unsatFat: toNum(f.nutrient?.unsatFat),
+              cholesterol: toNum(f.nutrient?.cholesterol),
+              sodium: toNum(f.nutrient?.sodium),
+              potassium: toNum(f.nutrient?.potassium),
+              caffeine: toNum(f.nutrient?.caffeine),
+            },
+          });
         });
       });
     });
 
-    const sortedFoods = Object.values(foodCount).sort((a, b) => b.count - a.count); // 내림차순 정렬
+    // createdAt 순으로 정렬
+    foods.sort((a, b) => {
+      if (a.date !== b.date) return b.date.localeCompare(a.date);
+      return b.createdAt.seconds - a.createdAt.seconds;
+    });
 
-    return sortedFoods;
+    // 중복 제거 후 최신것만 남김
+    const recentFoods = [];
+    const seen = new Set();
+    for (const food of foods) {
+      if (!seen.has(food.id)) {
+        seen.add(food.id);
+        recentFoods.push(food);
+      }
+    }
+
+    return recentFoods;
   } catch (error) {
     console.error('불러오기 중 오류 발생:', error);
     throw error;

--- a/yum-yum/src/services/searchFoodApi.js
+++ b/yum-yum/src/services/searchFoodApi.js
@@ -57,8 +57,12 @@ const parseNutritionData = (jsonData) => {
       },
       foodSize: size, // 기준량
       foodUnit: unit, // 식품 양 단위
-      makerName: item.mkrNm || '', // 제조사
-      company: item.companyNm || '', // 제조사
+      makerName:
+        item.companyNm && item.companyNm !== '해당없음'
+          ? item.companyNm
+          : item.mkrNm && item.mkrNm !== '해당없음'
+            ? item.mkrNm
+            : '',
     };
   });
 };

--- a/yum-yum/src/stores/useSelectedFoodsStore.js
+++ b/yum-yum/src/stores/useSelectedFoodsStore.js
@@ -1,29 +1,37 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
-export const useSelectedFoodsStore = create((set, get) => ({
-  selectedFoods: {},
+export const useSelectedFoodsStore = create(
+  persist(
+    (set, get) => ({
+      selectedFoods: {},
 
-  activeTab: 'frequent',
+      activeTab: 'frequent',
 
-  setActiveTab: (tab) => set({ activeTab: tab }),
+      setActiveTab: (tab) => set({ activeTab: tab }),
 
-  // 음식 선택 여부
-  isFoodSelected: (id) => Boolean(get().selectedFoods[id]),
+      // 음식 선택 여부
+      isFoodSelected: (id) => Boolean(get().selectedFoods[id]),
 
-  // 음식 추가/수정
-  addFood: (food) =>
-    set((state) => ({
-      selectedFoods: { ...state.selectedFoods, [food.id]: food },
-    })),
+      // 음식 추가/수정
+      addFood: (food) =>
+        set((state) => ({
+          selectedFoods: { ...state.selectedFoods, [food.id]: food },
+        })),
 
-  // 음식 삭제
-  deleteFood: (id) =>
-    set((state) => {
-      const copy = { ...state.selectedFoods };
-      delete copy[id];
-      return { selectedFoods: copy };
+      // 음식 삭제
+      deleteFood: (id) =>
+        set((state) => {
+          const copy = { ...state.selectedFoods };
+          delete copy[id];
+          return { selectedFoods: copy };
+        }),
+
+      // 전체 삭제
+      clearFoods: () => set({ selectedFoods: {} }),
     }),
-
-  // 전체 삭제
-  clearFoods: () => set({ selectedFoods: {} }),
-}));
+    {
+      name: 'selected-foods-storage',
+    },
+  ),
+);


### PR DESCRIPTION
## 📝 작업 개요
- 음식 선택 페이지 새로고침 시 데이터 유지 처리

## 🔨 작업 내용
- useSelectedFoodsStore.js > zustand 미들웨어 persist 사용하여 localStorage에 저장

## ✅ 테스트 방법
- 음식 선택 페이지 및 음식 선택 상세 페이지에서 새로고침 시 데이터 유지

## 📎 관련 이슈

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)