### PR TITLE
[feat] 로그인 로직 추가, 쿠키 유틸함수 추가

### DIFF
--- a/yum-yum/src/hooks/useAuth.js
+++ b/yum-yum/src/hooks/useAuth.js
@@ -1,10 +1,52 @@
 // 유저 로그인 상태 확인 훅
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+import toast from 'react-hot-toast';
+import { loginUser } from '../services/userApi';
+import { useUserStore } from '../stores/useUserStore';
 
 export default function useAuth() {
-  const [isAuthenticated, setIsAuthenticated] = useState(true); // 초기값을 true로 설정 (임시)
+  const {
+    user,
+    isAuthenticated, // default: false
+    isLoading,
+    error,
+    setLoading,
+    setError,
+    clearError,
+    loginSuccess,
+    loginFailure,
+    logout: logoutStore,
+  } = useUserStore();
 
-  // 이곳에서 쿠키를 확인하여 로그인 상태를 업데이트
+  // 로그인
+  const login = useCallback(
+    async (userId, password) => {
+      setLoading(true);
+      clearError();
 
-  return { isAuthenticated };
+      const result = await loginUser({ userid: userId, password });
+      // console.log(result);
+      if (result.success) {
+        loginSuccess(result.user.uid);
+        toast.success('로그인 성공!');
+        return { success: true };
+      } else {
+        loginFailure(result.error);
+        toast.error(result.error);
+        return { success: false, error: result.error };
+      }
+    },
+    [setLoading, clearError, loginSuccess, loginFailure],
+  );
+
+  // 이메일 중복확인
+
+  // 이메일 인증
+
+  // 회원가입
+
+  return {
+    isAuthenticated,
+    login,
+  };
 }

--- a/yum-yum/src/pages/auth/LoginPage.jsx
+++ b/yum-yum/src/pages/auth/LoginPage.jsx
@@ -1,43 +1,120 @@
 import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
 import logoImage from '@/assets/images/Group99.png';
 // 컴포넌트
 import Input from '@/components/common/Input';
 import BasicButton from '../../components/button/BasicButton';
 import { useNavigate } from 'react-router-dom';
+import useAuth from '../../hooks/useAuth';
 
 export default function LoginPage() {
+  const { login: setLogin } = useAuth();
   const navigate = useNavigate();
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    defaultValues: {
+      userId: '',
+      password: '',
+    },
+  });
+
+  const onSubmit = async (data) => {
+    // console.log('Form Data:', data);
+    // 로그인 로직
+    const result = await setLogin(data.userId, data.password);
+
+    if (result.success) {
+      navigate('/');
+    }
+  };
+
   return (
     <div className='flex flex-col gap-8 justify-center items-center bg-white w-full h-full min-h-screen'>
       <div className='flex justify-center items-center pb-8'>
         <img className='w-full h-30' src={logoImage} alt='오늘의 냠냠 로고' />
       </div>
       {/* login form section */}
-      <div className='flex flex-col items-center mb-4 w-full'>
-        <div className='flex flex-col gap-[8px] w-full px-8 mb-4'>
-          <Input id='userId' placeholder='이메일 입력' />
+      <form className='w-full' onSubmit={handleSubmit(onSubmit)}>
+        <div className='flex flex-col items-center mb-4 w-full'>
+          <div className='flex flex-col gap-[8px] w-full px-8 mb-4'>
+            <Controller
+              name='userId'
+              control={control}
+              rules={{
+                required: '이메일을 입력해주세요',
+                pattern: {
+                  value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                  message: '올바른 이메일 형식을 입력해주세요',
+                },
+              }}
+              render={({ field }) => (
+                <Input
+                  id='userId'
+                  placeholder='이메일 입력'
+                  type='email'
+                  value={field.value}
+                  onChange={field.onChange}
+                  status={errors.userId ? 'error' : 'default'}
+                  errorMessage={errors.userId?.message}
+                />
+              )}
+            />
+          </div>
+          <div className='flex flex-col gap-[8px] w-full px-8'>
+            <Controller
+              name='password'
+              control={control}
+              rules={{
+                required: '비밀번호를 입력해주세요',
+                minLength: {
+                  value: 8,
+                  message: '비밀번호는 8자 이상, 20자 이하여야 합니다.',
+                },
+                maxLength: {
+                  value: 20,
+                  message: '비밀번호는 8자 이상, 20자 이하여야 합니다.',
+                },
+                pattern: {
+                  value: /^(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{8,20}$/,
+                  message: '비밀번호는 영문자, 숫자, 특수문자가 최소 1개 이상 있어야합니다.',
+                },
+              }}
+              render={({ field }) => (
+                <Input
+                  id='password'
+                  type='password'
+                  placeholder='비밀번호 입력'
+                  value={field.value}
+                  onChange={field.onChange}
+                  status={errors.password ? 'error' : 'default'}
+                  errorMessage={errors.password?.message}
+                />
+              )}
+            />
+          </div>
         </div>
-        <div className='flex flex-col gap-[8px] w-full px-8'>
-          <Input id='password' placeholder='비밀번호 입력' />
-        </div>
-      </div>
-      {/* login form Button section */}
-      <div className='flex flex-col items-center w-full px-8'>
-        <div className='w-full mb-3'>
-          <BasicButton size='full' onClick={() => {}}>
-            로그인
+        {/* login form Button section */}
+        <div className='flex flex-col items-center w-full px-8'>
+          <div className='w-full mb-3'>
+            <BasicButton type='submit' size='full' onClick={handleSubmit}>
+              로그인
+            </BasicButton>
+          </div>
+          <BasicButton
+            size='full'
+            variant='line'
+            onClick={() => {
+              navigate('/signup');
+            }}
+            type='button'
+          >
+            회원가입
           </BasicButton>
         </div>
-        <BasicButton
-          size='full'
-          variant='line'
-          onClick={() => {
-            navigate('/signup');
-          }}
-        >
-          회원가입
-        </BasicButton>
-      </div>
+      </form>
     </div>
   );
 }

--- a/yum-yum/src/services/userApi.js
+++ b/yum-yum/src/services/userApi.js
@@ -1,6 +1,7 @@
 // services/userApi.js
-import { doc, getDoc } from 'firebase/firestore';
-import { firestore } from './firebase';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { auth, firestore } from './firebase';
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from 'firebase/auth';
 
 // 사용자 데이터 가져오기(전체 데이터)
 export async function getUserData(userId) {
@@ -46,5 +47,87 @@ export async function getUserWeightData(userId) {
       success: false,
       error: error.message,
     };
+  }
+}
+
+//-------------------------------------------------------
+
+// 유저 로그인
+export async function loginUser({ userid, password }) {
+  // console.log('service userid, password check:', userid, password);
+  try {
+    const userCredential = await signInWithEmailAndPassword(auth, userid, password);
+    const user = userCredential.user;
+
+    return {
+      success: true,
+      user,
+    };
+  } catch (error) {
+    throw new Error(error); // debug용
+    /*
+      return {
+        success: false,
+        error: error.message
+      }
+    */
+  }
+}
+
+// Firebase Authentication 계정 생성
+export async function registerUser({ username, userid, password }) {
+  try {
+    // Firebase Auth에 이메일/비밀번호로 계정 생성
+    const userCredential = await createUserWithEmailAndPassword(auth, userid, password);
+    const user = userCredential.user;
+
+    return {
+      success: true,
+      user,
+    };
+  } catch (error) {
+    throw new Error('ERROR: ', error); // debug 용
+    // return {
+    //   success: false,
+    //   error: error.message
+    // }
+  }
+}
+
+/**
+ * FireStore에 유저 정보 저장
+ * @param {Object} user
+ */
+const userDocData = (user) => {
+  return {
+    Uid: user.Uid,
+    userId: user.userId,
+    age: user.age,
+    gender: user.gender,
+    goals: { targetExercise: user.targetExercise, targetWeight: user.targetWeight },
+    height: user.height,
+    name: user.name,
+    oneTimeIntake: 500,
+    targetIntake: 1000,
+    weight: user.weight,
+  };
+};
+export async function addUserFireStroe(user) {
+  console.log(user);
+  try {
+    const userRef = doc(firestore, 'users', user.Uid);
+    const userData = userDocData(user);
+    setDoc(userRef, userData);
+
+    return {
+      success: true,
+      data: user.Uid,
+    };
+  } catch (error) {
+    throw new Error('ERROR: ', error); // debug 용
+    // return {
+    //   success: false,
+    //   error: error.message
+    // }
   }
 }

--- a/yum-yum/src/stores/useUserStore.js
+++ b/yum-yum/src/stores/useUserStore.js
@@ -1,0 +1,68 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const useUserStore = create(
+  persist(
+    (set, get) => ({
+      //상태
+      user: null,
+      isAuthenticated: true, //임시로 true 설정. 기본은 false
+      isLoading: false,
+      error: null,
+
+      // 액션들
+      setUser: (user) =>
+        set({
+          user,
+          isAuthenticated: !!user,
+          error: null,
+        }),
+
+      setLoading: (isLoading) => set({ isLoading }),
+      setError: (error) => set({ error }),
+      clearError: () => set({ error: null }),
+
+      // 로그인 상태 설정
+      loginSuccess: (user) =>
+        set({
+          user,
+          isAuthenticated: true,
+          isLoading: false,
+          error: null,
+        }),
+
+      loginFailure: (error) =>
+        set({
+          user: null,
+          isAuthenticated: false,
+          isLoading: false,
+          error,
+        }),
+
+      logout: () =>
+        set({
+          user: null,
+          isAuthenticated: false,
+          isLoading: false,
+          error: null,
+        }),
+
+      // 초기화
+      reset: () =>
+        set({
+          user: null,
+          isAuthenticated: false,
+          isLoading: false,
+          error: null,
+        }),
+    }),
+    // 로컬스토리지에 Uid와 로그인상태 저장
+    {
+      name: 'auth-storage', // localstorage key
+      partialize: (state) => ({
+        userId: state.user, //Uid
+        isAuthenticated: state.isAuthenticated, //로그인 상태
+      }),
+    },
+  ),
+);

--- a/yum-yum/src/utils/cookieUtils.js
+++ b/yum-yum/src/utils/cookieUtils.js
@@ -1,0 +1,22 @@
+// 쿠키를 설정하고 가져오는 유틸함수
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
+
+/**
+ * 쿠키 설정 함수
+ * @param {string} name
+ * @param {string} value
+ * @param {any} options?
+ */
+export const setCookie = (name, value, options = '') => {
+  return cookies.set(name, value, { ...options });
+};
+
+/**
+ * 쿠키 값 불러오는 함수
+ * @param {string} name : 쿠키 이름
+ */
+export const getCookie = (name) => {
+  return cookies.get(name);
+};


### PR DESCRIPTION
## 📝 작업 개요
- 로그인 로직 추가
- 쿠키 유틸함수 추가

## 🔨 작업 내용
- 로그인 로직 구현
    - LoginPage 에서 `react-hook-form` controlled 방식으로 데이터 핸들링
    - 커스텀 훅`useAuth`에 로그인 함수 추가
    - 로그인 상태나 값을 zustand persist으로 설정, localstorage에 isAuthenticated(로그인상태)와 Uid를 저장
  ```js
    // 로컬스토리지에 Uid와 로그인상태 저장
    {
      name: 'auth-storage', // localstorage key
      partialize: (state) => ({
        userId: state.user, //Uid
        isAuthenticated: state.isAuthenticated, //로그인 상태
      }),
    },
  ```
    - 로그인 관련은 firebase/auth를 바라보고 있음
- `cookieUtils`
    - 로그인 상태나 정보를 쿠키에 저장하려고 설정 함수를 만들어둠... 

## ✅ 테스트 방법
- `stores/useUserStore.js`에서 `isAuthenticated` 값을 false로 변경 후 테스트 시작
- 테스트용 로그인 정보: 회원가입 기능 만들어지면 아래계정 삭제
```
id: login-test@test.com
pwd: test1234!@
```

## 📎 관련 이슈