### PR TITLE
[feat] 회원가입 및 목표 설정 UI

### DIFF
--- a/yum-yum/src/App.jsx
+++ b/yum-yum/src/App.jsx
@@ -8,7 +8,7 @@ import MealPage from '@/pages/meal/MealPage';
 import ReportPage from '@/pages/report/pages/ReportPage';
 import WaterPage from '@/pages/water/WaterPage';
 import LoginPage from '@/pages/auth/LoginPage';
-import SignUpPage from '@/pages/auth/SignUpPage';
+import SignUpPage from '@/pages/auth/signup/SignUpPage';
 import NonUserHomePage from '@/pages/home/NonUserHomePage';
 import SimpleLayout from '@/components/layout/SimpleLayout';
 import Layout from '@/components/layout/Layout';

--- a/yum-yum/src/components/Header.jsx
+++ b/yum-yum/src/components/Header.jsx
@@ -7,7 +7,7 @@ import PrevIcon from '@/assets/icons/icon-left.svg?react';
 export default function Header() {
   const navigate = useNavigate();
   const isHeaderHiddenPage = location.pathname.startsWith('/meal'); // 헤더 없는 페이지
-  const isBackHiddenPage = ['/', '/report', '/mypage'].includes(location.pathname); // e뒤로가기 버튼 없는 페이지
+  const isBackHiddenPage = ['/', '/report', '/mypage', '/signup'].includes(location.pathname); // e뒤로가기 버튼 없는 페이지
 
   // 뒤로가기
   const handleBack = () => {

--- a/yum-yum/src/components/button/BasicButton.jsx
+++ b/yum-yum/src/components/button/BasicButton.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import clsx from 'clsx';
 
 export default function BasicButton({
+  type,
   size = 'md', // sm, md, lg, xl, full
   color = 'primary', // primary, secondary, gray
   variant = 'filled', // filled, line
@@ -12,6 +13,7 @@ export default function BasicButton({
 }) {
   return (
     <button
+      type={type}
       onClick={onClick}
       disabled={disabled}
       // h-12 px-5 bg-emerald-500 rounded-lg inline-flex justify-center items-center gap-2 overflow-hidden
@@ -21,6 +23,7 @@ export default function BasicButton({
         'px-5 h-12': size === 'md',
         'px-8 h-12': size === 'lg',
         'px-11 h-12': size === 'xl',
+        'w-[140px] h-12': size === '2xl',
         'w-full h-12': size === 'full',
         'bg-primary text-white': color === 'primary' && variant === 'filled' && !disabled,
         'bg-secondary text-white': color === 'secondary' && variant === 'filled' && !disabled,

--- a/yum-yum/src/main.jsx
+++ b/yum-yum/src/main.jsx
@@ -21,4 +21,4 @@ createRoot(document.getElementById('root')).render(
       <App />
     </QueryClientProvider>
   </CookiesProvider>,
-
+);

--- a/yum-yum/src/pages/auth/SignUpPage.jsx
+++ b/yum-yum/src/pages/auth/SignUpPage.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function SignUpPage() {
-  return <div>SignUpPage</div>;
-}

--- a/yum-yum/src/pages/auth/signup/SignUpPage.jsx
+++ b/yum-yum/src/pages/auth/signup/SignUpPage.jsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm, FormProvider } from 'react-hook-form';
+import toast from 'react-hot-toast';
+// 컴포넌트
+import Header from '@/components/Header';
+import SignupStep1 from './pages/SignupStep1';
+import SignupStep2 from './pages/SignupStep2';
+
+export default function SignUpPage() {
+  const navigate = useNavigate();
+  const methods = useForm({
+    defaultValues: {
+      name: '',
+      email: '',
+      pw: '',
+      pwCheck: '',
+      gender: '',
+      age: '',
+      height: '',
+      weight: '',
+      agreeAll: false,
+      service: false,
+      privacy: false,
+      sensitive: false,
+      goals: '',
+      targetWeight: '',
+      targetExercise: '',
+    },
+    mode: 'onBlur',
+  });
+  const [signUpStep, setSignUpStep] = useState(1);
+
+  const onSubmit = (data) => {
+    console.log('회원가입 데이터:', data);
+    toast.success('회원가입 완료');
+    navigate('/', {
+      replace: true,
+    });
+  };
+
+  return (
+    <div>
+      <Header />
+      <div className='flex items-center justify-between px-[20px] py-[20px]'>
+        <h3 className='text-2xl font-bold'>회원가입</h3>
+        <div className='w-[60px] py-1 bg-gray-200 font-bold text-center rounded-full'>
+          {signUpStep} / 2
+        </div>
+      </div>
+
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit(onSubmit)}>
+          {signUpStep === 1 && <SignupStep1 onNext={() => setSignUpStep(2)} />}
+          {signUpStep === 2 && <SignupStep2 onPrev={() => setSignUpStep(1)} />}
+        </form>
+      </FormProvider>
+    </div>
+  );
+}

--- a/yum-yum/src/pages/auth/signup/components/AgreementItem.jsx
+++ b/yum-yum/src/pages/auth/signup/components/AgreementItem.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+// 컴포넌트
+import CheckBox from '@/components/common/CheckBox';
+// 아이콘
+import NextIcon from '@/assets/icons/icon-right.svg?react';
+
+export default function AgreementItem({
+  id,
+  label,
+  checked,
+  onChange,
+  isNext = false,
+  isAll = false,
+  onOpenModal,
+  type,
+}) {
+  return (
+    <div className='flex items-center justify-between'>
+      <label
+        htmlFor={id}
+        className={`flex items-center gap-[8px] w-full cursor-pointer 
+                    ${isAll ? 'border-b border-gray-300 pb-[12px] mb-[12px]' : ''}
+                  `}
+      >
+        <CheckBox id={id} checked={checked} onChange={(e) => onChange(e.target.checked)} />
+        <p className={`${isAll ? 'font-bold' : 'text-gray-600 text-sm'}`}>{label}</p>
+      </label>
+
+      {isNext && (
+        <button
+          type='button'
+          onClick={() => onOpenModal?.(type)}
+          className='flex items-center justify-center'
+        >
+          <NextIcon className='ml-3' />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/yum-yum/src/pages/auth/signup/components/AgreementModal.jsx
+++ b/yum-yum/src/pages/auth/signup/components/AgreementModal.jsx
@@ -1,0 +1,134 @@
+import React from 'react';
+// 컴포넌트
+import Modal from '@/components/Modal';
+
+export default function AgreementModal({ isOpenModal, onCloseModal, type }) {
+  const agreementContent = () => {
+    switch (type) {
+      case 'service':
+        return {
+          title: '[필수] 서비스 이용약관 동의',
+          content: (
+            <div className='text-sm text-gray-600 max-h-[500px] overflow-y-auto'>
+              <p>제1조 (목적)</p>
+              <p className='pb-[12px]'>
+                본 약관은 회사가 제공하는 서비스 이용과 관련하여 회원과 회사 간의 권리, 의무 및 책임
+                사항을 규정합니다.
+              </p>
+
+              <p>제2조 (회원가입)</p>
+              <p className='pb-[12px]'>
+                회원은 이름, 이메일, 비밀번호, 성별, 나이, 키, 현재 체중, 목표 체중(상황에 따라
+                필수), 활동량(상황에 따라 필수)을 정확히 입력해야 하며, 허위 정보를 기재할 경우
+                서비스 이용이 제한될 수 있습니다.
+              </p>
+
+              <p>제3조 (서비스 제공)</p>
+              <p className='pb-[12px]'>
+                회사는 회원의 개인정보를 기반으로 맞춤형 식단 관리, 활동 분석 및 건강 목표 관리
+                서비스를 제공합니다.
+              </p>
+
+              <p>제4조 (회원의 의무)</p>
+              <p className='pb-[12px]'>
+                회원은 비밀번호를 안전하게 관리해야 하며, 타인의 개인정보를 도용하거나 허위 정보를
+                입력해서는 안 됩니다.
+              </p>
+
+              <p>제5조 (개인정보 보호)</p>
+              <p className='pb-[12px]'>
+                회사는 관련 법령을 준수하며, 회원의 개인정보를 안전하게 보호합니다. 자세한 내용은
+                개인정보 처리방침에 따릅니다.
+              </p>
+
+              <p>제6조 (서비스 제한 및 해지)</p>
+              <p className='pb-[12px]'>
+                회원이 약관을 위반하는 경우 회사는 서비스 이용을 제한하거나 회원 자격을 해지할 수
+                있습니다.
+              </p>
+            </div>
+          ),
+        };
+      case 'privacy':
+        return {
+          title: '[필수] 개인정보 수집 및 이용 동의',
+          content: (
+            <div className='text-sm text-gray-600 max-h-[500px] overflow-y-auto'>
+              <p>
+                오늘의 냠냠은 회원가입 및 서비스 제공을 위하여 아래와 같이 개인정보를
+                수집·이용합니다.
+              </p>
+
+              <p className='pt-[12px]'>1. 수집 항목</p>
+              <p className='pl-[12px]'>- 이름, 이메일(ID), 비밀번호</p>
+              <p className='pl-[12px]'>- 성별, 나이, 키, 현재 체중, 목표 체중, 활동량</p>
+
+              <p className='pt-[12px]'>2. 수집 목적</p>
+              <p className='pl-[12px]'>- 회원가입 및 본인 확인</p>
+              <p className='pl-[12px]'>- 서비스 제공 및 회원 관리</p>
+
+              <p className='pt-[12px]'>3. 보유 및 이용 기간</p>
+              <p className='pl-[12px]'>- 회원 탈퇴 시 즉시 삭제</p>
+              <p className='pl-[12px]'>
+                - 단, 관련 법령에 따라 일정 기간 보관이 필요한 경우 해당 법령에 따름
+              </p>
+              <p className='pl-[24px]'>- 계약 또는 청약철회 등에 관한 기록: 5년 (전자상거래법)</p>
+              <p className='pl-[24px]'>
+                - 부정이용 및 비정상 서비스 이용기록: 1년 (개인정보보호법)
+              </p>
+
+              <p className='pt-[12px]'>4. 동의 거부권 안내</p>
+              <p className='pl-[12px]'>- 회원은 개인정보 수집·이용에 동의하지 않을 수 있습니다.</p>
+              <p className='pl-[12px]'>
+                - 단, 필수 항목에 동의하지 않을 경우 회원가입이 제한됩니다.
+              </p>
+            </div>
+          ),
+        };
+      case 'sensitive':
+        return {
+          title: '[필수] 민감정보 수집 및 이용 동의',
+          content: (
+            <div className='text-sm text-gray-600 max-h-[500px] overflow-y-auto'>
+              <p>1. 수집 항목</p>
+              <p className='pl-[12px]'>- 키, 현재 체중, 목표 체중, 목표 유형</p>
+              <p className='pl-[12px] pb-[12px]'>- 식단 및 수분 기록, 칼로리·영양성분</p>
+
+              <p>2. 수집 목적</p>
+              <p className='pl-[12px]'>- 맞춤형 건강/식단 관리 서비스 제공</p>
+              <p className='pl-[12px] pb-[12px]'>- 체중·영양·활동량 분석 및 AI 피드백 제공</p>
+
+              <p>3. 보관 기간</p>
+              <p className='pl-[12px]'>- 회원 탈퇴 시 즉시 삭제</p>
+              <p className='pl-[12px] pb-[12px]'>
+                - 단, 관련 법령에 따라 일정 기간 보관 필요 시 해당 법령에 따름
+              </p>
+
+              <p>4. 동의 거부권 안내</p>
+              <p className='pl-[12px]'>- 회원은 개인정보 수집·이용에 동의하지 않을 수 있습니다.</p>
+              <p className='pl-[12px] pb-[12px]'>
+                - 단, 필수 항목에 동의하지 않을 경우 회원가입이 제한됩니다.
+              </p>
+            </div>
+          ),
+        };
+      default:
+        return { title: '', body: null };
+    }
+  };
+
+  const { title, content } = agreementContent();
+
+  return (
+    <Modal
+      isOpenModal={isOpenModal}
+      onCloseModal={onCloseModal}
+      title={title}
+      showClose={true}
+      btnLabel='확인'
+      onBtnClick={onCloseModal}
+    >
+      {content}
+    </Modal>
+  );
+}

--- a/yum-yum/src/pages/auth/signup/components/AgreementsSection.jsx
+++ b/yum-yum/src/pages/auth/signup/components/AgreementsSection.jsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+// 컴포넌트
+import AgreementItem from './AgreementItem';
+import AgreementModal from './AgreementModal';
+
+export default function AgreementsSection() {
+  const [openModal, setOpenModal] = useState(null);
+  const { control, setValue, watch } = useFormContext();
+  const service = watch('service');
+  const privacy = watch('privacy');
+  const sensitive = watch('sensitive');
+
+  // 전체 동의 체크박스
+  const handleAllChange = (checked) => {
+    setValue('service', checked);
+    setValue('privacy', checked);
+    setValue('sensitive', checked);
+  };
+
+  return (
+    <div className='p-[20px]'>
+      <div className=' p-[20px] border border-gray-300 rounded-xl'>
+        <Controller
+          name='agreeAll'
+          control={control}
+          rules={{
+            validate: () => (service && privacy && sensitive) || '필수 약관에 모두 동의해주세요.',
+          }}
+          render={({ field }) => (
+            <AgreementItem
+              {...field}
+              id='agreeAll'
+              label='약관 전체 동의'
+              checked={service && privacy && sensitive}
+              onChange={handleAllChange}
+              isAll
+            />
+          )}
+        />
+
+        <div className='flex flex-col gap-[4px]'>
+          <Controller
+            name='service'
+            control={control}
+            render={({ field }) => (
+              <AgreementItem
+                {...field}
+                id='service'
+                checked={service}
+                label='[필수] 서비스 이용약관 동의'
+                isNext
+                type='service'
+                onOpenModal={setOpenModal}
+              />
+            )}
+          />
+
+          <Controller
+            name='privacy'
+            control={control}
+            render={({ field }) => (
+              <AgreementItem
+                {...field}
+                id='privacy'
+                checked={privacy}
+                label='[필수] 개인정보 수집 및 이용 동의'
+                isNext
+                type='privacy'
+                onOpenModal={setOpenModal}
+              />
+            )}
+          />
+
+          <Controller
+            name='sensitive'
+            control={control}
+            render={({ field }) => (
+              <AgreementItem
+                {...field}
+                id='sensitive'
+                checked={sensitive}
+                label='[필수] 민감정보 수집 및 이용 동의'
+                isNext
+                type='sensitive'
+                onOpenModal={setOpenModal}
+              />
+            )}
+          />
+        </div>
+      </div>
+
+      {/* 에러 메세지 */}
+      <Controller
+        name='agreeAll'
+        control={control}
+        render={({ fieldState }) =>
+          fieldState.error && (
+            <p className='text-[var(--color-error)] text-sm mt-2'>{fieldState.error.message}</p>
+          )
+        }
+      />
+
+      {/* 약관 자세히 보기 모달 */}
+      {openModal && (
+        <AgreementModal
+          isOpenModal={!!openModal}
+          onCloseModal={() => setOpenModal(null)}
+          type={openModal}
+        />
+      )}
+    </div>
+  );
+}

--- a/yum-yum/src/pages/auth/signup/pages/SignupStep1.jsx
+++ b/yum-yum/src/pages/auth/signup/pages/SignupStep1.jsx
@@ -1,0 +1,272 @@
+import React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+// 컴포넌트
+import BasicButton from '@/components/button/BasicButton';
+import Input from '@/components/common/Input';
+import AgreementsSection from '../components/AgreementsSection';
+
+export default function SignupStep1({ onNext }) {
+  const { control, handleSubmit, watch } = useFormContext();
+  const pw = watch('pw');
+
+  // 성별
+  const genderOption = [
+    { value: 'female', label: '여성' },
+    { value: 'male', label: '남성' },
+  ];
+
+  return (
+    <>
+      <div className='flex flex-col gap-[20px] px-[20px]'>
+        {/* 이름 */}
+        <Controller
+          name='name'
+          control={control}
+          rules={{
+            required: '이름을 입력해주세요',
+            minLength: { value: 2, message: '2자 이상 입력해주세요.' },
+            maxLength: { value: 5, message: '5자 이하로 입력해주세요.' },
+            pattern: { value: /^[가-힣]+$/, message: '한글만 입력 가능해요.' },
+          }}
+          render={({ field, fieldState }) => (
+            <div className='flex flex-col gap-[8px]'>
+              <label htmlFor='name' className='text-sm font-bold text-gray-500'>
+                이름 <strong className='text-secondary font-extrabold'>*</strong>
+              </label>
+              <Input
+                {...field}
+                id='name'
+                placeholder='이름'
+                status={fieldState.error ? 'error' : 'default'}
+                errorMessage={fieldState.error?.message}
+                maxLength='5'
+              />
+            </div>
+          )}
+        />
+
+        {/* 이메일 */}
+        <Controller
+          name='email'
+          control={control}
+          rules={{
+            required: '이메일을 입력해주세요',
+            pattern: {
+              value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+              message: '올바른 이메일 형식이 아니에요.',
+            },
+            // 이메일 중복확인 추가
+          }}
+          render={({ field, fieldState }) => (
+            <div className='flex flex-col gap-[8px]'>
+              <label htmlFor='email' className='text-sm font-bold text-gray-500'>
+                이메일 <strong className='text-secondary font-extrabold'>*</strong>
+              </label>
+              <div className='flex gap-[12px]'>
+                <Input
+                  {...field}
+                  id='email'
+                  placeholder='yumyum@gmail.com'
+                  status={fieldState.error ? 'error' : 'default'}
+                  errorMessage={fieldState.error?.message}
+                  className='flex-1'
+                />
+                <BasicButton
+                  type='button'
+                  size='2xl'
+                  onClick={() => console.log('중복 확인:', field.value)}
+                >
+                  중복확인
+                </BasicButton>
+              </div>
+            </div>
+          )}
+        />
+
+        {/* 비밀번호 */}
+        <Controller
+          name='pw'
+          control={control}
+          rules={{
+            required: '비밀번호를 입력해주세요',
+            minLength: { value: 8, message: '8자 이상 입력해주세요.' },
+            maxLength: { value: 20, message: '20자 이하로 입력해주세요.' },
+            pattern: {
+              value: /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>]).{8,20}$/,
+              message: '영문, 숫자, 특수문자를 모두 포함해야 해요.',
+            },
+          }}
+          render={({ field, fieldState }) => (
+            <div className='flex flex-col gap-[8px]'>
+              <label htmlFor='pw' className='text-sm font-bold text-gray-500'>
+                비밀번호 <strong className='text-secondary font-extrabold'>*</strong>
+              </label>
+              <Input
+                {...field}
+                id='pw'
+                type='password'
+                placeholder='영문, 숫자, 특수문자 포함 8~20자'
+                status={fieldState.error ? 'error' : 'default'}
+                errorMessage={fieldState.error?.message}
+                maxLength='20'
+              />
+            </div>
+          )}
+        />
+
+        {/* 비밀번호 확인 */}
+        <Controller
+          name='pwCheck'
+          control={control}
+          rules={{
+            required: '비밀번호 확인을 입력해주세요',
+            validate: (value) => value === pw || '비밀번호가 일치하지 않아요.',
+          }}
+          render={({ field, fieldState }) => (
+            <div className='flex flex-col gap-[8px]'>
+              <label htmlFor='pwCheck' className='text-sm font-bold text-gray-500'>
+                비밀번호 확인 <strong className='text-secondary font-extrabold'>*</strong>
+              </label>
+              <Input
+                {...field}
+                id='pwCheck'
+                type='password'
+                placeholder='영문, 숫자, 특수문자 포함 8~20자'
+                status={fieldState.error ? 'error' : 'default'}
+                errorMessage={fieldState.error?.message}
+                maxLength='20'
+              />
+            </div>
+          )}
+        />
+
+        {/* 성별 */}
+        <Controller
+          name='gender'
+          control={control}
+          rules={{
+            required: '성별을 선택해주세요',
+          }}
+          render={({ field, fieldState }) => (
+            <div className='flex flex-col gap-[8px]'>
+              <label htmlFor='gender' className='text-sm font-bold text-gray-500'>
+                성별 <strong className='text-secondary font-extrabold'>*</strong>
+              </label>
+              <div className='flex gap-[12px]'>
+                {genderOption.map((gender) => (
+                  <BasicButton
+                    key={gender.value}
+                    type='button'
+                    size='full'
+                    variant={field.value === gender.value ? 'filled' : 'line'}
+                    onClick={() => {
+                      field.onChange(gender.value);
+                    }}
+                  >
+                    {gender.label}
+                  </BasicButton>
+                ))}
+              </div>
+              {fieldState.error && (
+                <p className='text-[var(--color-error)] text-sm'>{fieldState.error.message}</p>
+              )}
+            </div>
+          )}
+        />
+
+        {/* 나이 */}
+        <Controller
+          name='age'
+          control={control}
+          rules={{
+            required: '나이를 입력해주세요',
+            min: { value: 14, message: '14세 이상만 가입 가능해요.' },
+            max: { value: 120, message: '나이를 다시 확인해주세요.' },
+          }}
+          render={({ field, fieldState }) => (
+            <div className='flex flex-col gap-[8px]'>
+              <label htmlFor='age' className='text-sm font-bold text-gray-500'>
+                나이 <strong className='text-secondary font-extrabold'>*</strong>
+              </label>
+              <Input
+                {...field}
+                id='age'
+                type='number'
+                noSpinner
+                placeholder='0'
+                endAdornment='세'
+                status={fieldState.error ? 'error' : 'default'}
+                errorMessage={fieldState.error?.message}
+              />
+            </div>
+          )}
+        />
+
+        {/* 키 */}
+        <Controller
+          name='height'
+          control={control}
+          rules={{
+            required: '키를 입력해주세요',
+            min: { value: 50, message: '50cm 이상 입력해주세요.' },
+            max: { value: 250, message: '250cm 이하로 입력해주세요.' },
+          }}
+          render={({ field, fieldState }) => (
+            <div className='flex flex-col gap-[8px]'>
+              <label htmlFor='height' className='text-sm font-bold text-gray-500'>
+                키 <strong className='text-secondary font-extrabold'>*</strong>
+              </label>
+              <Input
+                {...field}
+                id='height'
+                type='number'
+                noSpinner
+                placeholder='0'
+                endAdornment='cm'
+                status={fieldState.error ? 'error' : 'default'}
+                errorMessage={fieldState.error?.message}
+              />
+            </div>
+          )}
+        />
+
+        {/* 현재 체중 */}
+        <Controller
+          name='weight'
+          control={control}
+          rules={{
+            required: '현재 체중을 입력해주세요',
+            min: { value: 20, message: '20kg 이상 입력해주세요.' },
+            max: { value: 300, message: '300kg 이하로 입력해주세요.' },
+          }}
+          render={({ field, fieldState }) => (
+            <div className='flex flex-col gap-[8px]'>
+              <label htmlFor='weight' className='text-sm font-bold text-gray-500'>
+                현재 체중 <strong className='text-secondary font-extrabold'>*</strong>
+              </label>
+              <Input
+                {...field}
+                htmlFor='weight'
+                type='number'
+                noSpinner
+                placeholder='0'
+                endAdornment='kg'
+                status={fieldState.error ? 'error' : 'default'}
+                errorMessage={fieldState.error?.message}
+              />
+            </div>
+          )}
+        />
+      </div>
+
+      {/* 약관 동의 */}
+      <AgreementsSection />
+
+      <div className='p-[20px] bg-white'>
+        <BasicButton size='full' onClick={handleSubmit(onNext)}>
+          다음
+        </BasicButton>
+      </div>
+    </>
+  );
+}

--- a/yum-yum/src/pages/auth/signup/pages/SignupStep1.jsx
+++ b/yum-yum/src/pages/auth/signup/pages/SignupStep1.jsx
@@ -180,6 +180,10 @@ export default function SignupStep1({ onNext }) {
           control={control}
           rules={{
             required: '나이를 입력해주세요',
+            pattern: {
+              value: /^[0-9]+$/,
+              message: '숫자만 입력 가능합니다',
+            },
             min: { value: 14, message: '14세 이상만 가입 가능해요.' },
             max: { value: 120, message: '나이를 다시 확인해주세요.' },
           }}
@@ -208,6 +212,10 @@ export default function SignupStep1({ onNext }) {
           control={control}
           rules={{
             required: '키를 입력해주세요',
+            pattern: {
+              value: /^[0-9]+$/,
+              message: '숫자만 입력 가능합니다',
+            },
             min: { value: 50, message: '50cm 이상 입력해주세요.' },
             max: { value: 250, message: '250cm 이하로 입력해주세요.' },
           }}
@@ -236,6 +244,10 @@ export default function SignupStep1({ onNext }) {
           control={control}
           rules={{
             required: '현재 체중을 입력해주세요',
+            pattern: {
+              value: /^(?:\d{1,3}(?:\.\d)?|)$/,
+              message: '소수점 첫째 자리까지 입력 가능합니다',
+            },
             min: { value: 20, message: '20kg 이상 입력해주세요.' },
             max: { value: 300, message: '300kg 이하로 입력해주세요.' },
           }}
@@ -246,10 +258,11 @@ export default function SignupStep1({ onNext }) {
               </label>
               <Input
                 {...field}
-                htmlFor='weight'
+                id='weight'
                 type='number'
                 noSpinner
-                placeholder='0'
+                step='0.1'
+                placeholder='00.0'
                 endAdornment='kg'
                 status={fieldState.error ? 'error' : 'default'}
                 errorMessage={fieldState.error?.message}

--- a/yum-yum/src/pages/auth/signup/pages/SignupStep2.jsx
+++ b/yum-yum/src/pages/auth/signup/pages/SignupStep2.jsx
@@ -66,6 +66,7 @@ export default function SignupStep2({ onPrev }) {
           rules={{
             validate: (value) => {
               if (!value) return true;
+              if (!/^\d{1,3}(\.\d)?$/.test(value)) return '소수점 첫째 자리까지만 입력 가능합니다';
               if (value < 20) return '20kg 이상 입력해주세요.';
               if (value > 300) return '300kg 이하로 입력해주세요.';
             },
@@ -80,7 +81,8 @@ export default function SignupStep2({ onPrev }) {
                 id='targetWeight'
                 type='number'
                 noSpinner
-                placeholder='0'
+                step='0.1'
+                placeholder='00.0'
                 endAdornment='kg'
                 status={fieldState.error ? 'error' : 'default'}
                 errorMessage={fieldState.error?.message}

--- a/yum-yum/src/pages/auth/signup/pages/SignupStep2.jsx
+++ b/yum-yum/src/pages/auth/signup/pages/SignupStep2.jsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+// 컴포넌트
+import Input from '@/components/common/Input';
+import BasicButton from '@/components/button/BasicButton';
+
+export default function SignupStep2({ onPrev }) {
+  const { control, watch } = useFormContext();
+  const targetWeightValue = watch('targetWeight');
+
+  // 목표 설정
+  const goalsOption = [
+    { value: '', label: '목표 선택' },
+    { value: 'loss', label: '체중 감량' },
+    { value: 'gain', label: '체중 증가' },
+    { value: 'maintain', label: '건강증진 및 유지' },
+  ];
+
+  // 활동량
+  const activityLevel = [
+    { value: 'none', title: '운동 안함', sub: '일주일에 운동 0회' },
+    { value: 'light', title: '가벼운 운동', sub: '주 1-3회, 30분씩 (산책, 요가)' },
+    { value: 'moderate', title: '적당한 운동', sub: '주 3-5회, 45분씩 (헬스, 수영)' },
+    { value: 'intense', title: '격렬한 운동', sub: '주 6-7회, 1시간씩 (크로스핏, 마라톤 훈련)' },
+  ];
+
+  return (
+    <div>
+      <div className=' flex flex-col gap-[20px] min-h-[calc(100vh-220px)] px-[20px]'>
+        {/* 목표 설정 */}
+        <div className='flex flex-col gap-[8px]'>
+          <label htmlFor='goals' className='text-sm font-bold text-gray-500'>
+            목표 설정 <strong className='text-secondary font-extrabold'>*</strong>
+          </label>
+          <Controller
+            name='goals'
+            control={control}
+            rules={{ required: '목표를 선택해주세요' }}
+            render={({ field, fieldState }) => (
+              <>
+                <select
+                  {...field}
+                  id='goals'
+                  className='w-full h-[48px] px-4 border border-[var(--color-gray-300)] rounded-lg transition-colors outline-none'
+                >
+                  {goalsOption.map((goal) => (
+                    <option key={goal.value} value={goal.value}>
+                      {goal.label}
+                    </option>
+                  ))}
+                </select>
+                {fieldState.error && (
+                  <p className='text-[var(--color-error)] text-sm mt-1'>
+                    {fieldState.error.message}
+                  </p>
+                )}
+              </>
+            )}
+          />
+        </div>
+
+        {/* 목표 체중 */}
+        <Controller
+          name='targetWeight'
+          control={control}
+          rules={{
+            required: '목표 체중을 입력해주세요',
+            min: { value: 20, message: '20kg 이상 입력해주세요.' },
+            max: { value: 300, message: '300kg 이하로 입력해주세요.' },
+          }}
+          render={({ field, fieldState }) => (
+            <div className='flex flex-col gap-[8px]'>
+              <label htmlFor='targetWeight' className='text-sm font-bold text-gray-500'>
+                목표 체중
+              </label>
+              <Input
+                {...field}
+                id='targetWeight'
+                type='number'
+                noSpinner
+                placeholder='0'
+                endAdornment='kg'
+                status={fieldState.error ? 'error' : 'default'}
+                errorMessage={fieldState.error?.message}
+                maxLength='3'
+              />
+              {!targetWeightValue && !fieldState.error && (
+                <p className='text-[var(--color-error)] text-sm'>
+                  감량(혹은 증량) 목표 달성을 위해 목표 체중을 입력해주세요
+                </p>
+              )}
+            </div>
+          )}
+        />
+
+        {/* 활동량*/}
+        <Controller
+          name='targetExercise'
+          control={control}
+          rules={{
+            required: '활동량을 선택해주세요',
+          }}
+          render={({ field, fieldState }) => (
+            <div className='flex flex-col gap-[8px]'>
+              <label htmlFor='targetExercise' className='text-sm font-bold text-gray-500'>
+                활동량 <strong className='text-secondary font-extrabold'>*</strong>
+              </label>
+              <div className='flex flex-col gap-[16px]'>
+                {activityLevel.map((a) => (
+                  <button
+                    key={a.value}
+                    type='button'
+                    onClick={() => field.onChange(a.value)}
+                    className={`flex flex-col gap-[8px] py-[20px] px-[28px] border border-gray-300 rounded-2xl text-left
+                                ${field.value === a.value ? 'border-primary bg-primary-light' : ''}
+                              `}
+                  >
+                    <h4
+                      className={`font-bold text-lg ${field.value === a.value ? 'text-primary-dark' : ''}`}
+                    >
+                      {a.title}
+                    </h4>
+                    <p className='text-gray-500 text-sm'>{a.sub}</p>
+                  </button>
+                ))}
+              </div>
+              {fieldState.error && (
+                <p className='text-[var(--color-error)] text-sm mt-1'>{fieldState.error.message}</p>
+              )}
+            </div>
+          )}
+        />
+      </div>
+
+      <div className='sticky bottom-0 z-30 flex gap-[12px] p-[20px] bg-white'>
+        <BasicButton size='full' variant='line' onClick={onPrev}>
+          이전
+        </BasicButton>
+        <BasicButton size='full' type='submit'>
+          오늘의 냠냠 시작하기
+        </BasicButton>
+      </div>
+    </div>
+  );
+}

--- a/yum-yum/src/pages/auth/signup/pages/SignupStep2.jsx
+++ b/yum-yum/src/pages/auth/signup/pages/SignupStep2.jsx
@@ -64,9 +64,11 @@ export default function SignupStep2({ onPrev }) {
           name='targetWeight'
           control={control}
           rules={{
-            required: '목표 체중을 입력해주세요',
-            min: { value: 20, message: '20kg 이상 입력해주세요.' },
-            max: { value: 300, message: '300kg 이하로 입력해주세요.' },
+            validate: (value) => {
+              if (!value) return true;
+              if (value < 20) return '20kg 이상 입력해주세요.';
+              if (value > 300) return '300kg 이하로 입력해주세요.';
+            },
           }}
           render={({ field, fieldState }) => (
             <div className='flex flex-col gap-[8px]'>


### PR DESCRIPTION
## 📝 작업 개요
- 회원가입 및 목표 설정 페이지 UI

## 🔨 작업 내용
- 회원가입 및 목표 설정 페이지 UI
- 버튼 컴포넌트 type, size 추가

## ✅ 테스트 방법
-  /signup 페이지로 이동
- 이름: 2~5자, 한글 입력 가능
- 이메일: 이메일 정규식 미 입력 시 에러 메세지
- 비밀번호: 영문, 숫자, 특수문자 포함 8~20자
- 비밀번호 확인: 비밀번호와 다를 경우 에러 메세지
- 성별: 미선택 시 에러 메세지
- 나이: 14~120, 숫자만 입력 가능
- 키: 50~250, 숫자만 입력 가능
- 현재 체중 20~300, 소수점 첫째 자리까지 입력 가능
- 약관 하나라도 미체크 시 에러 메세지

- 목표 설정: 미선택 시 에러 메세지
- 목표 체중: 20~300, 소수점 첫째 자리까지 입력 가능, 필수 입력 아님
- 활동량: 미선택 시 에러 메세지

## 📎 관련 이슈

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)