### PR TITLE
[fix] 플로팅 버튼에서도 기존 식단이 있는경우 상세 페이지로 이동

### DIFF
--- a/yum-yum/src/components/common/OnBoarding.jsx
+++ b/yum-yum/src/components/common/OnBoarding.jsx
@@ -1,9 +1,17 @@
 // 온보드 화면(전체화면)
-import React from 'react';
+import React, { useEffect } from 'react';
 import BasicButton from '@/components/button/BasicButton';
 
 export default function OnBoarding({ isOpen = false, onClose }) {
+  // 온보딩 호출 시 스크롤 막기
+  useEffect(() => {
+    if (!isOpen) return;
+    document.body.style.overflow = 'hidden';
+    return () => (document.body.style.overflow = 'auto');
+  }, [isOpen]);
+
   if (!isOpen) return null;
+
   return (
     <div className='fixed inset-0 z-50 bg-white'>
       <div className='w-full h-full overflow-auto flex items-start justify-center'>

--- a/yum-yum/src/components/modal/MenuModal.jsx
+++ b/yum-yum/src/components/modal/MenuModal.jsx
@@ -1,7 +1,7 @@
-// 식사 type 선택 후, 값 어떻게 넘겨야하는지?
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useHomeStore } from '../../stores/useHomeStore';
+import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
 
 const menuItems = [
   { id: '1', name: '아침', key: 'breakfast' },
@@ -13,12 +13,16 @@ const menuItems = [
 export default function MenuModal({ isOpen, onClose }) {
   if (!isOpen) return null;
   const navigate = useNavigate();
-  const { selectedDate } = useHomeStore();
+  const { selectedDate, originalMealData } = useHomeStore();
+  const { clearFoods, addFood } = useSelectedFoodsStore();
 
   const menuSelected = (item) => {
-    // 선택 값 => 식단 입력 이동
-    // console.log('item: ', item.name);
-    navigate(`/meal/${item.key}`, {
+    // mealdata에 데이터 필터링 => addFood에 입력
+    clearFoods();
+    const copy = originalMealData?.[item.key];
+    copy?.map((meal) => addFood(meal));
+    // 선택 값 => 식단 total 이동
+    navigate(`/meal/${item.key}/total`, {
       state: { date: selectedDate, formMain: true },
     });
     // 창 닫기

--- a/yum-yum/src/components/modal/MenuModal.jsx
+++ b/yum-yum/src/components/modal/MenuModal.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useHomeStore } from '../../stores/useHomeStore';
 import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
@@ -11,10 +11,18 @@ const menuItems = [
 ];
 
 export default function MenuModal({ isOpen, onClose }) {
-  if (!isOpen) return null;
   const navigate = useNavigate();
   const { selectedDate, originalMealData } = useHomeStore();
   const { clearFoods, addFood } = useSelectedFoodsStore();
+
+  // 모달 호출 시 스크롤 막기
+  useEffect(() => {
+    if (!isOpen) return;
+    document.body.style.overflow = 'hidden';
+    return () => (document.body.style.overflow = 'auto');
+  }, [isOpen]);
+
+  if (!isOpen) return null;
 
   const menuSelected = (item) => {
     // mealdata에 데이터 필터링 => addFood에 입력
@@ -30,8 +38,13 @@ export default function MenuModal({ isOpen, onClose }) {
   };
   return (
     // dark overlay 수정, 모달 하단 정렬
-    <div className='fixed inset-0 bg-black/30 flex justify-center items-end z-50 '>
-      <div className='bg-white rounded-lg p-4 w-full opacity-100'>
+    <>
+      <div
+        onClick={onClose}
+        className='fixed z-40 left-1/2 bottom-0 -translate-x-1/2 w-full max-w-[500px] h-full bg-black opacity-60'
+      ></div>
+
+      <div className='fixed z-50 left-1/2 bottom-0 -translate-x-1/2 flex flex-col w-full max-w-[500px] bg-white rounded-t-3xl p-5'>
         <ul className='text-center space-y-2'>
           <li className=' text-gray-500 p-2 border-b border-gray-300'>선택해주세요</li>
           {menuItems.map((item) => (
@@ -50,6 +63,6 @@ export default function MenuModal({ isOpen, onClose }) {
           </li>
         </ul>
       </div>
-    </div>
+    </>
   );
 }

--- a/yum-yum/src/stores/useHomeStore.js
+++ b/yum-yum/src/stores/useHomeStore.js
@@ -13,6 +13,7 @@ export const useHomeStore = create((set, get) => ({
   // 호출 값들
   waterData: null, //{current, goal}
   mealData: null, // {id, breackfast, lunch, dinner, snack}
+  originalMealData: null, // 원본 식단 데이터
 
   // UI 상태
   selectedDate: new Date(),
@@ -56,7 +57,7 @@ export const useHomeStore = create((set, get) => ({
       targetIntake: userData?.targetIntake,
     });
     const meal = normalizerMeal(data.mealData[0]);
-    set({ waterData: water, mealData: meal });
+    set({ waterData: water, mealData: meal, originalMealData: data.mealData[0]?.meals });
   },
 
   // 초기화


### PR DESCRIPTION
## 📝 작업 개요
- 플로팅 버튼 > 식단 추가하기 > 기존 식단이 있는 경우 meal/{type}/total 페이지로 이동 #86

## 🔨 작업 내용
- zustand에 원본 데이터를 저장하여 `menumodal`에서도 사용할 수 있게 추가
- `selectedFoodsStore`에 값이 없는경우 추가페이지로 이동을 하는 것을 확인
- 음식 선택 리스트에 해당 타입(아침,점심,저녁,기타)에 이미 입력한 값을 추가하여 `/total`로 이동하도록 설정

## ✅ 테스트 방법
- 메인 페이지에서 09-17 혹은 09-16 선택
- 플로트 버튼으로 식단 추가 -> 이미 식단이 기록된 타입 선택 
- 상세페이지로 이동하는지 확인

## 📎 관련 이슈
- Close #86 

### 📸 스크린샷(선택)
- 메인에서 9월 16일로 날짜 설정 후, 플로트 버튼 -> 식단 추가 선택하여 모달 표출
<img width="492" height="932" alt="스크린샷 2025-09-19 오전 11 39 09" src="https://github.com/user-attachments/assets/7e3ff65f-1ea3-4937-986b-6466cfb53156" />

- 아침 선택했을 때, 아래와 같이 상세페이지로 이동
<img width="506" height="933" alt="스크린샷 2025-09-19 오전 11 39 15" src="https://github.com/user-attachments/assets/a1a452f5-8069-417e-89f5-ba6d2cb8dbc8" />

## 🎯 리뷰 요구사항(선택)