### PR TITLE
[fix] 플로트 버튼에서 물 추가 시, 선택한 날짜에 추가 적용

### DIFF
--- a/yum-yum/src/components/button/FloatButton.jsx
+++ b/yum-yum/src/components/button/FloatButton.jsx
@@ -7,8 +7,10 @@ import IconMeal from '@/assets/icons/icon-restaurant.svg?react';
 import MenuModal from '@/components/modal/MenuModal';
 import { useNavigate } from 'react-router-dom';
 import RoundButton from './RoundButton';
+import { useHomeStore } from '../../stores/useHomeStore';
 
 export default function FloatButton({ onClick, isOpen, isClose, disabled }) {
+  const { selectedDate } = useHomeStore();
   const [modalOpen, setModalOpen] = useState(false);
   const navigate = useNavigate();
 
@@ -19,7 +21,8 @@ export default function FloatButton({ onClick, isOpen, isClose, disabled }) {
         <div className='space-y-2 flex flex-col z-50'>
           <RoundButton
             onClick={() => {
-              navigate('/water');
+              // navigate('/water');
+              navigate(`/water`, { state: { date: selectedDate } });
             }}
             color='gray'
             variant='filled'

--- a/yum-yum/src/components/modal/MenuModal.jsx
+++ b/yum-yum/src/components/modal/MenuModal.jsx
@@ -17,18 +17,12 @@ export default function MenuModal({ isOpen, onClose }) {
 
   // 모달 호출 시 스크롤 막기
   useEffect(() => {
-    if (!isOpen) return;
-    document.body.style.overflow = 'hidden';
-    return () => (document.body.style.overflow = 'auto');
-  }, [isOpen]);
-
-  if (!isOpen) return null;
-
-  // 모달 호출 시 스크롤 막기
-  useEffect(() => {
-    if (!isOpen) return;
-    document.body.style.overflow = 'hidden';
-    return () => (document.body.style.overflow = 'auto');
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
   }, [isOpen]);
 
   if (!isOpen) return null;
@@ -42,9 +36,10 @@ export default function MenuModal({ isOpen, onClose }) {
     navigate(`/meal/${item.key}/total`, {
       state: { date: selectedDate, formMain: true },
     });
-    // 창 닫기
-    onClose;
+    // ✅ Fix: Actually call the onClose function
+    onClose();
   };
+
   return (
     // dark overlay 수정, 모달 하단 정렬
     <>


### PR DESCRIPTION
## 📝 작업 개요
- 다른날짜 선택하고 플로팅버튼의 물추가하기하면 오늘날짜 섭취량 나오고 수정도 불가능한 이슈 발생

## 🔨 작업 내용
- `navigate` 설정 시, `state` 값 추가
- 모달에 동일한 `useEffect`가 두개 있어서 하나로 줄임

## ✅ 테스트 방법
- 오늘날짜가 아닌 다른 날짜 선택 후 플로트 버튼에서 물 추가 진행
- 만약 물을 마신 기록이 있으면 해당 기록이 나타날 것
- 물을 추가한 뒤, 저장 후 메인 화면에 적용이 되어있는지 확인

## 📎 관련 이슈
- Close #이슈번호(선택)

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)