### PR TITLE
[fix] `useNutritionAnalysis` 캐싱 로직 개선 및 중복 useEffect 제거

### DIFF
--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -21,30 +21,23 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
   const query = useQuery({
     queryKey,
     queryFn: async () => {
-      // 1. 같은 시간대에 이미 API를 실행했으면 다시 생성하지 않고
-      // 로컬스토리지 플래그만 보고 fetchAIResultWithCache 로 조회
-      const alreadyRun = hasExecutedInTimePeriod(today, periodKey, dataHash);
-      // 2. 가능하면 우선 DB cache 조회
-      if (alreadyRun) {
-        const cached = await fetchAIResultWithCache(
-          userId,
-          {
-            date: selectedDate,
-            type: meals.type,
-          },
-          dataHash,
-        );
-        // DB에 성공적으로 들어있는 데이터가 있으면 리턴
-        if (cached?.success) {
-          markExecutedInTimePeriod(today, periodKey, dataHash);
-          return cached;
-        }
+      // 1. 가능하면 우선 DB cache 조회
+      const cached = await fetchAIResultWithCache(
+        userId,
+        {
+          date: selectedDate,
+          type: meals.type,
+        },
+        dataHash,
+      );
+      // DB에 성공적으로 들어있는 데이터가 있으면 리턴
+      if (cached?.success) {
+        return cached;
       }
 
+      console.log('db에 없거나 아직 한번도 안 실행한 경우 AI 생성');
       // 3. DB에 없거나 아직 한번도 안 실행한 경우 AI 생성
       const fresh = await generateNutritionAnalysis(userId, meals, dataHash);
-      // 로컬스토리지에 이 시간대 생성완료 표시
-      markExecutedInTimePeriod(today, periodKey, dataHash);
       return fresh;
     },
     // enabled: false,

--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -36,6 +36,7 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
         );
         // DB에 성공적으로 들어있는 데이터가 있으면 리턴
         if (cached?.success) {
+          markExecutedInTimePeriod(today, periodKey, dataHash);
           return cached;
         }
       }
@@ -43,7 +44,7 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
       // 3. DB에 없거나 아직 한번도 안 실행한 경우 AI 생성
       const fresh = await generateNutritionAnalysis(userId, meals, dataHash);
       // 로컬스토리지에 이 시간대 생성완료 표시
-      // markExecutedInTimePeriod(today, periodKey, dataHash);
+      markExecutedInTimePeriod(today, periodKey, dataHash);
       return fresh;
     },
     // enabled: false,
@@ -71,80 +72,3 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
     isCached,
   };
 };
-
-// // AI Api 캐싱, 상태관리
-// import { useQuery, useQueryClient } from '@tanstack/react-query';
-// import { generateNutritionAnalysis, fetchAIResultWithCache } from '../services/nutritionAnalysis';
-// import { generateDataHash } from '../utils/hashUtils';
-// import { getTodayKey } from '../utils/dateUtils';
-// import { hasExecutedInTimePeriod, markExecutedInTimePeriod } from '@/utils/localStorage';
-// import { useEffect, useState } from 'react';
-
-// export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTimePeriod) => {
-//   const queryClient = useQueryClient();
-//   const dataHash = generateDataHash(meals);
-//   const today = getTodayKey(selectedDate);
-//   const periodKey = currentTimePeriod?.key;
-
-//   const queryKey = periodKey
-//     ? ['nutrition-analysis', today, periodKey, dataHash]
-//     : ['nutrition-analysis', 'invalid-time'];
-
-//   // 1) useQuery: enabled: false → 필요할 때만 수동 호출
-//   const query = useQuery({
-//     queryKey,
-//     queryFn: () => generateNutritionAnalysis(userId, meals),
-//     enabled: false,
-//     staleTime: 1000 * 60 * 60 * 24,
-//     gcTime: 1000 * 60 * 60 * 24 * 7,
-//     refetchOnWindowFocus: false,
-//     refetchOnMount: false,
-//     retry: (count, err) => count < 3 && err.type === 'RESOURCE_EXHAUSTED',
-//     retryDelay: (n) => Math.min(1000 * 2 ** n, 30_000),
-//   });
-
-//   // 2) “한 시간대당 한 번만 AI 생성” useEffect
-//   useEffect(() => {
-//     if (!meals.date || !periodKey) return;
-//     console.log('useQuery key:', queryKey);
-//     console.log('cache data for key:', queryClient.getQueryData(queryKey));
-//     if (!hasExecutedInTimePeriod(today, periodKey, dataHash)) {
-//       query
-//         .refetch()
-//         .then(() => {
-//           markExecutedInTimePeriod(today, periodKey, dataHash);
-//         })
-//         .catch(console.error);
-//     }
-//     // meals.date, meals.type 만 deps 에 넣어야 객체 참조 변경으로 재실행되는 걸 방지
-//   }, [meals.date, meals.type, periodKey, today, dataHash, query, queryClient, queryKey]);
-
-//   // 3) “이미 캐시가 있으면 fetchAIResultWithCache” useEffect
-//   //    → 한번만 실행할 수 있게 플래그로 또 막아주자
-//   const isCached = queryClient.getQueryData(queryKey) !== undefined;
-//   const [didFetchCachedResult, setDidFetchCachedResult] = useState(false);
-
-//   useEffect(() => {
-//     console.log(isCached, didFetchCachedResult);
-//     if (!hasExecutedInTimePeriod(today, periodKey, dataHash)) return; // 호출 한 적이 없으면 패스
-//     if (didFetchCachedResult) return; // 이미 한 번 불렀으면 패스
-
-//     setDidFetchCachedResult(true); // 플래그 세팅
-//     fetchAIResultWithCache(userId, { date: selectedDate, type: meals.type })
-//       .then((cachedRes) => {
-//         // 가져온 AI 메시지도 react-query 캐시에 함께 세팅
-//         queryClient.setQueryData(queryKey, cachedRes);
-//       })
-//       .catch(console.error);
-
-//     // meals.date, meals.type
-//   }, [isCached, didFetchCachedResult, userId, meals.date, meals.type, queryClient, queryKey]);
-
-//   return {
-//     ...query,
-//     dataHash,
-//     todayKey: today,
-//     periodKey,
-//     isCached,
-//   };
-// };

--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -4,8 +4,6 @@ import { generateNutritionAnalysis, fetchAIResultWithCache } from '../services/n
 import { generateDataHash } from '../utils/hashUtils';
 import { getTodayKey } from '../utils/dateUtils';
 import { hasExecutedInTimePeriod, markExecutedInTimePeriod } from '@/utils/localStorage';
-import { useEffect, useState } from 'react';
-import { is } from 'date-fns/locale';
 
 export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTimePeriod) => {
   const queryClient = useQueryClient();

--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -27,12 +27,11 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
       // 로컬스토리지 플래그만 보고 fetchAIResultWithCache 로 조회
       const alreadyRun = hasExecutedInTimePeriod(today, periodKey, dataHash);
       // 2. 가능하면 우선 DB cache 조회
-      if (!isCached || alreadyRun) {
+      if (alreadyRun) {
         const cached = await fetchAIResultWithCache(userId, {
           date: selectedDate,
           type: meals.type,
         });
-        console.log('cached', cached);
         // DB에 성공적으로 들어있는 데이터가 있으면 리턴
         if (cached?.success) {
           return cached;

--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -42,7 +42,7 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
         .catch(console.error);
     }
     // meals.date, meals.type 만 deps 에 넣어야 객체 참조 변경으로 재실행되는 걸 방지
-  }, [meals.date, meals.type, periodKey, today, dataHash, query]);
+  }, [meals.date, meals.type, periodKey, today, dataHash, query, queryClient, queryKey]);
 
   // 3) “이미 캐시가 있으면 fetchAIResultWithCache” useEffect
   //    → 한번만 실행할 수 있게 플래그로 또 막아주자

--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -26,10 +26,14 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
       const alreadyRun = hasExecutedInTimePeriod(today, periodKey, dataHash);
       // 2. 가능하면 우선 DB cache 조회
       if (alreadyRun) {
-        const cached = await fetchAIResultWithCache(userId, {
-          date: selectedDate,
-          type: meals.type,
-        });
+        const cached = await fetchAIResultWithCache(
+          userId,
+          {
+            date: selectedDate,
+            type: meals.type,
+          },
+          dataHash,
+        );
         // DB에 성공적으로 들어있는 데이터가 있으면 리턴
         if (cached?.success) {
           return cached;
@@ -37,7 +41,7 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
       }
 
       // 3. DB에 없거나 아직 한번도 안 실행한 경우 AI 생성
-      const fresh = await generateNutritionAnalysis(userId, meals);
+      const fresh = await generateNutritionAnalysis(userId, meals, dataHash);
       // 로컬스토리지에 이 시간대 생성완료 표시
       // markExecutedInTimePeriod(today, periodKey, dataHash);
       return fresh;

--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -5,6 +5,7 @@ import { generateDataHash } from '../utils/hashUtils';
 import { getTodayKey } from '../utils/dateUtils';
 import { hasExecutedInTimePeriod, markExecutedInTimePeriod } from '@/utils/localStorage';
 import { useEffect, useState } from 'react';
+import { is } from 'date-fns/locale';
 
 export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTimePeriod) => {
   const queryClient = useQueryClient();
@@ -16,54 +17,50 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
     ? ['nutrition-analysis', today, periodKey, dataHash]
     : ['nutrition-analysis', 'invalid-time'];
 
+  const isCached = queryClient.getQueryData(queryKey) !== undefined;
+
   // 1) useQuery: enabled: false → 필요할 때만 수동 호출
   const query = useQuery({
     queryKey,
-    queryFn: () => generateNutritionAnalysis(userId, meals),
-    enabled: false,
+    queryFn: async () => {
+      // 1. 같은 시간대에 이미 API를 실행했으면 다시 생성하지 않고
+      // 로컬스토리지 플래그만 보고 fetchAIResultWithCache 로 조회
+      const alreadyRun = hasExecutedInTimePeriod(today, periodKey, dataHash);
+      // 2. 가능하면 우선 DB cache 조회
+      if (!isCached || alreadyRun) {
+        const cached = await fetchAIResultWithCache(userId, {
+          date: selectedDate,
+          type: meals.type,
+        });
+        console.log('cached', cached);
+        // DB에 성공적으로 들어있는 데이터가 있으면 리턴
+        if (cached?.success) {
+          return cached;
+        }
+      }
+
+      // 3. DB에 없거나 아직 한번도 안 실행한 경우 AI 생성
+      const fresh = await generateNutritionAnalysis(userId, meals);
+      // 로컬스토리지에 이 시간대 생성완료 표시
+      // markExecutedInTimePeriod(today, periodKey, dataHash);
+      return fresh;
+    },
+    // enabled: false,
+    enabled: !!periodKey && !!meals.date,
     staleTime: 1000 * 60 * 60 * 24,
     gcTime: 1000 * 60 * 60 * 24 * 7,
     refetchOnWindowFocus: false,
-    refetchOnMount: false,
+    refetchOnMount: true,
     retry: (count, err) => count < 3 && err.type === 'RESOURCE_EXHAUSTED',
     retryDelay: (n) => Math.min(1000 * 2 ** n, 30_000),
+    onSuccess: (data) => {
+      // generateNutritionAnalysis 에서 성공적으로 생성된 데이터가 오면
+      // react-query 캐시에 함께 세팅
+      if (!hasExecutedInTimePeriod(today, periodKey, dataHash)) {
+        markExecutedInTimePeriod(today, periodKey, dataHash);
+      }
+    },
   });
-
-  // 2) “한 시간대당 한 번만 AI 생성” useEffect
-  useEffect(() => {
-    if (!meals.date || !periodKey) return;
-
-    if (!hasExecutedInTimePeriod(today, periodKey, dataHash)) {
-      query
-        .refetch()
-        .then(() => {
-          markExecutedInTimePeriod(today, periodKey, dataHash);
-        })
-        .catch(console.error);
-    }
-    // meals.date, meals.type 만 deps 에 넣어야 객체 참조 변경으로 재실행되는 걸 방지
-  }, [meals.date, meals.type, periodKey, today, dataHash, query, queryClient, queryKey]);
-
-  // 3) “이미 캐시가 있으면 fetchAIResultWithCache” useEffect
-  //    → 한번만 실행할 수 있게 플래그로 또 막아주자
-  const isCached = queryClient.getQueryData(queryKey) !== undefined;
-  const [didFetchCachedResult, setDidFetchCachedResult] = useState(false);
-
-  useEffect(() => {
-    // console.log(isCached, didFetchCachedResult);
-    if (!hasExecutedInTimePeriod(today, periodKey, dataHash)) return; // 호출 한 적이 없으면 패스
-    if (didFetchCachedResult) return; // 이미 한 번 불렀으면 패스
-
-    setDidFetchCachedResult(true); // 플래그 세팅
-    fetchAIResultWithCache(userId, { date: selectedDate, type: meals.type })
-      .then((cachedRes) => {
-        // 가져온 AI 메시지도 react-query 캐시에 함께 세팅
-        queryClient.setQueryData(queryKey, cachedRes);
-      })
-      .catch(console.error);
-
-    // meals.date, meals.type
-  }, [isCached, didFetchCachedResult, userId, meals.date, meals.type, queryClient, queryKey]);
 
   return {
     ...query,
@@ -73,3 +70,80 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
     isCached,
   };
 };
+
+// // AI Api 캐싱, 상태관리
+// import { useQuery, useQueryClient } from '@tanstack/react-query';
+// import { generateNutritionAnalysis, fetchAIResultWithCache } from '../services/nutritionAnalysis';
+// import { generateDataHash } from '../utils/hashUtils';
+// import { getTodayKey } from '../utils/dateUtils';
+// import { hasExecutedInTimePeriod, markExecutedInTimePeriod } from '@/utils/localStorage';
+// import { useEffect, useState } from 'react';
+
+// export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTimePeriod) => {
+//   const queryClient = useQueryClient();
+//   const dataHash = generateDataHash(meals);
+//   const today = getTodayKey(selectedDate);
+//   const periodKey = currentTimePeriod?.key;
+
+//   const queryKey = periodKey
+//     ? ['nutrition-analysis', today, periodKey, dataHash]
+//     : ['nutrition-analysis', 'invalid-time'];
+
+//   // 1) useQuery: enabled: false → 필요할 때만 수동 호출
+//   const query = useQuery({
+//     queryKey,
+//     queryFn: () => generateNutritionAnalysis(userId, meals),
+//     enabled: false,
+//     staleTime: 1000 * 60 * 60 * 24,
+//     gcTime: 1000 * 60 * 60 * 24 * 7,
+//     refetchOnWindowFocus: false,
+//     refetchOnMount: false,
+//     retry: (count, err) => count < 3 && err.type === 'RESOURCE_EXHAUSTED',
+//     retryDelay: (n) => Math.min(1000 * 2 ** n, 30_000),
+//   });
+
+//   // 2) “한 시간대당 한 번만 AI 생성” useEffect
+//   useEffect(() => {
+//     if (!meals.date || !periodKey) return;
+//     console.log('useQuery key:', queryKey);
+//     console.log('cache data for key:', queryClient.getQueryData(queryKey));
+//     if (!hasExecutedInTimePeriod(today, periodKey, dataHash)) {
+//       query
+//         .refetch()
+//         .then(() => {
+//           markExecutedInTimePeriod(today, periodKey, dataHash);
+//         })
+//         .catch(console.error);
+//     }
+//     // meals.date, meals.type 만 deps 에 넣어야 객체 참조 변경으로 재실행되는 걸 방지
+//   }, [meals.date, meals.type, periodKey, today, dataHash, query, queryClient, queryKey]);
+
+//   // 3) “이미 캐시가 있으면 fetchAIResultWithCache” useEffect
+//   //    → 한번만 실행할 수 있게 플래그로 또 막아주자
+//   const isCached = queryClient.getQueryData(queryKey) !== undefined;
+//   const [didFetchCachedResult, setDidFetchCachedResult] = useState(false);
+
+//   useEffect(() => {
+//     console.log(isCached, didFetchCachedResult);
+//     if (!hasExecutedInTimePeriod(today, periodKey, dataHash)) return; // 호출 한 적이 없으면 패스
+//     if (didFetchCachedResult) return; // 이미 한 번 불렀으면 패스
+
+//     setDidFetchCachedResult(true); // 플래그 세팅
+//     fetchAIResultWithCache(userId, { date: selectedDate, type: meals.type })
+//       .then((cachedRes) => {
+//         // 가져온 AI 메시지도 react-query 캐시에 함께 세팅
+//         queryClient.setQueryData(queryKey, cachedRes);
+//       })
+//       .catch(console.error);
+
+//     // meals.date, meals.type
+//   }, [isCached, didFetchCachedResult, userId, meals.date, meals.type, queryClient, queryKey]);
+
+//   return {
+//     ...query,
+//     dataHash,
+//     todayKey: today,
+//     periodKey,
+//     isCached,
+//   };
+// };

--- a/yum-yum/src/pages/meal/MealPage.jsx
+++ b/yum-yum/src/pages/meal/MealPage.jsx
@@ -35,7 +35,7 @@ export default function MealPage() {
 
   // 돋보기 아이콘 클릭, 엔터
   const handleSearchSubmit = () => {
-    console.log(searchInputValue);
+    // console.log(searchInputValue);
     // FoodSearchResult.jsx 페이지로 이동
     navigate(`/meal/search`, {
       state: { searchInputValue, type, date },

--- a/yum-yum/src/pages/meal/page/FoodSearchResults.jsx
+++ b/yum-yum/src/pages/meal/page/FoodSearchResults.jsx
@@ -23,7 +23,7 @@ export default function FoodSearchResultsPage() {
   // 음식 검색
   useEffect(() => {
     if (searchData) {
-      console.log('검색결과:', searchData);
+      // console.log('검색결과:', searchData);
       setSearchFoodResults(searchData);
     }
   }, [searchData]);


### PR DESCRIPTION
## 📝 작업 개요
- `useNutritionAnalysis` 훅 내부에 AI 생성(refetch)용, DB 캐시 조회용 두 개의 `useEffect`가 분리되어 있어
  1) AI 생성 성공 → React-Query 캐시에 정상 저장  
  2) 곧바로 DB 캐시 조회 → 아직 DB에 없다는 `no-cache` 응답으로 캐시를 덮어쓰는 문제 발생  
- 결과적으로 AI 분석 내용이 사라지거나 잘못 표시되는 버그가 있음

## 🔨 작업 내용
- 두 개의 `useEffect` 및 `didFetchCachedResult` 상태 삭제
- `useQuery` 하나로 통합
  - `queryFn` 내부에서
    1. 로컬스토리지 플래그(`hasExecutedInTimePeriod`) 확인
    2. 플래그가 있으면 `fetchAIResultWithCache()` 로 DB 캐시 조회 → 성공 시 즉시 반환
    3. 없거나 실패 시 `generateNutritionAnalysis()` 호출
  - `onSuccess` 콜백에서 `markExecutedInTimePeriod()` 로 플래그 세팅  
- `enabled` 및 `refetchOnMount` 옵션 조정으로, `periodKey`/`meals.date` 준비 시 자동 호출되도록 변경  
- 중복된 상태 관리 및 이펙트 제거로 로직 단순화

## ✅ 테스트 방법
1. 최초 마운트
    - `periodKey`/`meals.date`가 준비된 상태에서 컴포넌트 렌더링
    - AI 생성이 호출되고 React-Query 캐시에 정상 저장
    - 로컬스토리지에 해당 시간대 플래그가 세팅되어있는지 확인
2. 같은 시간대 재렌더링
    - 페이지 새로고침 또는 컴포넌트 언마운트 후 재마운트
    - `fetchAIResultWithCache`를 통해 DB데이터를 즉시 반환
    - `generateNutritionAnalysis`가 재실행되지 않는지 확인
3. DB 캐시에 없는 경우
    - DB 캐시를 의도적으로 비워둔 상태에서 재실행
    - `generateNutritionAnalysis` 로직으로 fallback 되는지 확인

## 📎 관련 이슈

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)

- `queryFn` 내 로직 흐름(플래그 체크 → 캐시 조회 → AI 생성)이 가독성/유지보수성 측면에서 적절한지
- `enabled` 및 `refetchOnMount` 옵션 설정이 의도한 대로 동작하는지
- 중복 이펙트 제거로 인한 부작용 발생 하는지

