### PR TITLE
[fix] 음식 검색 시, 중복 제거와 칼로리 및 영양성분 100g기준 계산

### DIFF
--- a/yum-yum/src/hooks/useSearchFoodData.js
+++ b/yum-yum/src/hooks/useSearchFoodData.js
@@ -7,6 +7,7 @@ export const useSearchFoodData = (searchKeyword) => {
   const searchFoodDataQuery = useQuery({
     queryKey: ['searchFoodData', searchKeyword],
     queryFn: () => fetchNutritionData(searchKeyword),
+    select: (data) => removeDuplicateFoods(data), // 중복 키 제거 함수 적용
     staleTime: 60 * 60 * 1000,
     enabled: !!searchKeyword,
   });
@@ -17,4 +18,17 @@ export const useSearchFoodData = (searchKeyword) => {
     isError: searchFoodDataQuery.isError,
     refetch: searchFoodDataQuery.refetch,
   };
+};
+
+// 검색 한 데이터 중복 키 제거
+const removeDuplicateFoods = (foods) => {
+  const foodCd = new Set();
+  const uniqueFoods = foods.filter((food) => {
+    if (foodCd.has(food.id)) {
+      return false;
+    }
+    foodCd.add(food.id);
+    return true;
+  });
+  return uniqueFoods;
 };

--- a/yum-yum/src/services/searchFoodApi.js
+++ b/yum-yum/src/services/searchFoodApi.js
@@ -37,23 +37,26 @@ const parseNutritionData = (jsonData) => {
     return [items]; // 단일 객체인 경우 배열로 변환
   }
   // 필요하면 더 추가
+  // console.log(items);
   return items.map((item) => {
     const { amount: size, unit } = parsedFoodSize(item.foodSize);
+    const { amount: serving, unit: servingUnit } = parsedFoodSize(item.nutConSrtrQua);
+    // console.log(size, unit, serving, servingUnit);
     return {
       id: item.foodCd,
       foodCode: item.foodCd, // 음식코드
       foodName: item.foodNm, // 음식명
       nutrient: {
-        kcal: parseFloat(item.enerc) || 0, // 칼로리
-        carbs: parseFloat(item.chocdf) || 0, // 탄수화물
-        fat: parseFloat(item.fatce) || 0, // 지방
-        sugar: parseFloat(item.sugar) || 0, // 당분
-        fiber: parseFloat(item.fibtg) || 0, // 식이섬유
-        satFat: parseFloat(item.fasat) || 0, // 포화 지방
-        transFat: parseFloat(item.fatrn) || 0, // 트랜스지방
-        cholesterol: parseFloat(item.chole) || 0, // 콜레스테롤
-        sodium: parseFloat(item.nat) || 0, // 나트륨
-        protein: parseFloat(item.prot) || 0, // 단백질
+        kcal: Math.round(parsedKcalAndNutrients(parseFloat(item.enerc), serving, size)) || 0, // 칼로리
+        carbs: parsedKcalAndNutrients(parseFloat(item.chocdf), serving, size) || 0, // 탄수화물
+        fat: parsedKcalAndNutrients(parseFloat(item.fatce), serving, size) || 0, // 지방
+        sugar: parsedKcalAndNutrients(parseFloat(item.sugar), serving, size) || 0, // 당분
+        fiber: parsedKcalAndNutrients(parseFloat(item.fibtg), serving, size) || 0, // 식이섬유
+        satFat: parsedKcalAndNutrients(parseFloat(item.fasat), serving, size) || 0, // 포화 지방
+        transFat: parsedKcalAndNutrients(parseFloat(item.fatrn), serving, size) || 0, // 트랜스지방
+        cholesterol: parsedKcalAndNutrients(parseFloat(item.chole), serving, size) || 0, // 콜레스테롤
+        sodium: parsedKcalAndNutrients(parseFloat(item.nat), serving, size) || 0, // 나트륨
+        protein: parsedKcalAndNutrients(parseFloat(item.prot), serving, size) || 0, // 단백질
       },
       foodSize: size, // 기준량
       foodUnit: unit, // 식품 양 단위
@@ -80,4 +83,9 @@ const parsedFoodSize = (foodSize) => {
     };
   }
   return { amount: null, unit: foodSize };
+};
+
+// 칼로리 및 영양정보 파싱 함수
+const parsedKcalAndNutrients = (food, serving, size) => {
+  return Number((food * (size / serving)).toFixed(2));
 };


### PR DESCRIPTION
## 📝 작업 개요
- 음식 검색 시, 결과에 중복된 음식이 표현됨
- 이전에 검색한 내용이 함께 보여지는 버그 발생
- 음식의 칼로리가 실제 g과 맞지 않음

## 🔨 작업 내용
- `useSearchFoodData` : 검색한 데이터 중복 키 제거
- `searchFoodApi` : 리턴 전 칼로리 및 영양정보 파싱함수 추가

## ✅ 테스트 방법
- '햇반'을 검색한다.
    - 작업 전 : 150kcal(210g 기준)
    - 작업 후 : 315kcal(210g 기준)

## 📎 관련 이슈
- [같은 항목 중복 추가](https://www.notion.so/goormkdx/278c0ff4ce31808a8d82e6e4d4ced0dc)
- [검색 결과 중복항목 제거](https://www.notion.so/goormkdx/277c0ff4ce318067b3beda045081a0e1)
- [식품의약품안전처 API 데이터 정확성 검토 필요](https://www.notion.so/goormkdx/api-API-278c0ff4ce31805c926ec71618772805)