### PR TITLE
[fix] 0칼로리 음식 입력 시, 홈 화면에서 칼로리 및 수정버튼으로 바뀌지 않은 이슈

### DIFF
--- a/yum-yum/src/hooks/useSearchFoodData.js
+++ b/yum-yum/src/hooks/useSearchFoodData.js
@@ -7,6 +7,7 @@ export const useSearchFoodData = (searchKeyword) => {
   const searchFoodDataQuery = useQuery({
     queryKey: ['searchFoodData', searchKeyword],
     queryFn: () => fetchNutritionData(searchKeyword),
+    select: (data) => removeDuplicateFoods(data), // 중복 키 제거 함수 적용
     staleTime: 60 * 60 * 1000,
     enabled: !!searchKeyword,
   });
@@ -17,4 +18,17 @@ export const useSearchFoodData = (searchKeyword) => {
     isError: searchFoodDataQuery.isError,
     refetch: searchFoodDataQuery.refetch,
   };
+};
+
+// 검색 한 데이터 중복 키 제거
+const removeDuplicateFoods = (foods) => {
+  const foodCd = new Set();
+  const uniqueFoods = foods.filter((food) => {
+    if (foodCd.has(food.id)) {
+      return false;
+    }
+    foodCd.add(food.id);
+    return true;
+  });
+  return uniqueFoods;
 };

--- a/yum-yum/src/pages/home/card/nutrition/MealCard.jsx
+++ b/yum-yum/src/pages/home/card/nutrition/MealCard.jsx
@@ -35,7 +35,7 @@ const MealCard = ({
             <div className='flex-1'>
               <div className='flex items-center gap-2 mb-2'>
                 <h3 className='text-gray-800 text-xl font-extrabold'>{section.title}</h3>
-                {section.data.calories > 0 && (
+                {section.data.foods && section.data.foods.length > 0 && (
                   <div className='flex items-baseline gap-2'>
                     <span className='text-gray-800 text-2xl font-extrabold'>
                       {Math.round(section.data?.calories)}
@@ -49,9 +49,8 @@ const MealCard = ({
                 {section.data.foods || '아직 기록이 없습니다'}
               </p>
             </div>
-
             <CheckButton
-              hasData={section.data.calories > 0}
+              hasData={section.data.foods && section.data.foods.length > 0}
               onClick={() => {
                 if (section.data.calories > 0) {
                   onUpdateMeal(meals._id, section.key);

--- a/yum-yum/src/services/searchFoodApi.js
+++ b/yum-yum/src/services/searchFoodApi.js
@@ -37,23 +37,26 @@ const parseNutritionData = (jsonData) => {
     return [items]; // 단일 객체인 경우 배열로 변환
   }
   // 필요하면 더 추가
+  // console.log(items);
   return items.map((item) => {
     const { amount: size, unit } = parsedFoodSize(item.foodSize);
+    const { amount: serving, unit: servingUnit } = parsedFoodSize(item.nutConSrtrQua);
+    // console.log(size, unit, serving, servingUnit);
     return {
       id: item.foodCd,
       foodCode: item.foodCd, // 음식코드
       foodName: item.foodNm, // 음식명
       nutrient: {
-        kcal: parseFloat(item.enerc) || 0, // 칼로리
-        carbs: parseFloat(item.chocdf) || 0, // 탄수화물
-        fat: parseFloat(item.fatce) || 0, // 지방
-        sugar: parseFloat(item.sugar) || 0, // 당분
-        fiber: parseFloat(item.fibtg) || 0, // 식이섬유
-        satFat: parseFloat(item.fasat) || 0, // 포화 지방
-        transFat: parseFloat(item.fatrn) || 0, // 트랜스지방
-        cholesterol: parseFloat(item.chole) || 0, // 콜레스테롤
-        sodium: parseFloat(item.nat) || 0, // 나트륨
-        protein: parseFloat(item.prot) || 0, // 단백질
+        kcal: Math.round(parsedKcalAndNutrients(parseFloat(item.enerc), serving, size)) || 0, // 칼로리
+        carbs: parsedKcalAndNutrients(parseFloat(item.chocdf), serving, size) || 0, // 탄수화물
+        fat: parsedKcalAndNutrients(parseFloat(item.fatce), serving, size) || 0, // 지방
+        sugar: parsedKcalAndNutrients(parseFloat(item.sugar), serving, size) || 0, // 당분
+        fiber: parsedKcalAndNutrients(parseFloat(item.fibtg), serving, size) || 0, // 식이섬유
+        satFat: parsedKcalAndNutrients(parseFloat(item.fasat), serving, size) || 0, // 포화 지방
+        transFat: parsedKcalAndNutrients(parseFloat(item.fatrn), serving, size) || 0, // 트랜스지방
+        cholesterol: parsedKcalAndNutrients(parseFloat(item.chole), serving, size) || 0, // 콜레스테롤
+        sodium: parsedKcalAndNutrients(parseFloat(item.nat), serving, size) || 0, // 나트륨
+        protein: parsedKcalAndNutrients(parseFloat(item.prot), serving, size) || 0, // 단백질
       },
       foodSize: size, // 기준량
       foodUnit: unit, // 식품 양 단위
@@ -80,4 +83,9 @@ const parsedFoodSize = (foodSize) => {
     };
   }
   return { amount: null, unit: foodSize };
+};
+
+// 칼로리 및 영양정보 파싱 함수
+const parsedKcalAndNutrients = (food, serving, size) => {
+  return Number((food * (size / serving)).toFixed(2));
 };


### PR DESCRIPTION
## 📝 작업 개요
- 0칼로리 음식 입력 시, 홈 화면에서 칼로리 및 수정버튼으로 바뀌지 않은 이슈

## 🔨 작업 내용
- 음식데이터가 없는 기준 판단을 칼로리가 아닌 foods(음식이름)으로 판단

## ✅ 테스트 방법
- 0칼로리의 음식을 직접 등록 후, 입력
- 홈 화면에 0칼로리 음식이 나타나며 0칼로리가 화면에 떠있어야함

## 📎 관련 이슈

### 📸 스크린샷(선택)
<img width="491" height="508" alt="스크린샷 2025-09-25 오후 2 43 08" src="https://github.com/user-attachments/assets/2580124f-411a-4a1c-9d3f-2b29010e3767" />

## 🎯 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
