### PR TITLE
[feat] 체중 입력 시, 다른 날짜 선택 가능

### DIFF
--- a/yum-yum/src/components/common/DateHeader.jsx
+++ b/yum-yum/src/components/common/DateHeader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import IconNoresult from '@/assets/icons/icon-noresult.svg?react';
+import DateSelector from './DateSelector';
 
 export default function DateHeader({
   date = new Date(),
@@ -14,7 +15,7 @@ export default function DateHeader({
   const formattedDate = format(date, dateFormat, { locale: ko });
 
   return (
-    <div className={`w-full h-16 bg-white shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] ${className}`}>
+    <div className={`w-full h-16 bg-white  ${className}`}>
       {/* Flexbox 컨테이너 */}
       <div className='h-full flex items-center justify-between px-4'>
         {/* 왼쪽 빈 공간 (균형 맞추기 위해) */}
@@ -22,20 +23,7 @@ export default function DateHeader({
 
         {/* 중앙: 날짜 + 캘린더 버튼 */}
         <div className='flex items-center gap-2'>
-          <h1 className='text-black text-xl font-bold whitespace-nowrap'>{formattedDate}</h1>
-
-          {/* 날짜 옆 캘린더 버튼 */}
-          <button
-            className='w-7 h-7 flex items-center justify-center
-                       hover:bg-gray-100 rounded-md transition-colors duration-200
-                       focus:outline-none focus:ring-2 focus:ring-blue-300'
-            onClick={onCalendarClick}
-            aria-label='날짜 선택'
-          >
-            <svg className='w-4 h-4' viewBox='0 0 12 10' fill='currentColor'>
-              <path d='M6 10L0 0h12L6 10z' className='text-emerald-500' />
-            </svg>
-          </button>
+          <DateSelector onCalendarClick={onCalendarClick} formattedDate={formattedDate} />
         </div>
 
         {/* 오른쪽: 온보딩 버튼 */}

--- a/yum-yum/src/components/common/DateSelector.jsx
+++ b/yum-yum/src/components/common/DateSelector.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function DateSelector({ onCalendarClick, formattedDate }) {
+  return (
+    <>
+      <h1 className='text-black text-xl font-bold whitespace-nowrap'>{formattedDate}</h1>
+
+      {/* 날짜 옆 캘린더 버튼 */}
+      <button
+        className='w-7 h-7 flex items-center justify-center
+                       hover:bg-gray-100 rounded-md transition-colors duration-200
+                       focus:outline-none focus:ring-2 focus:ring-blue-300'
+        onClick={onCalendarClick}
+        aria-label='날짜 선택'
+      >
+        <svg className='w-4 h-4' viewBox='0 0 12 10' fill='currentColor'>
+          <path d='M6 10L0 0h12L6 10z' className='text-emerald-500' />
+        </svg>
+      </button>
+    </>
+  );
+}

--- a/yum-yum/src/hooks/useWeight.js
+++ b/yum-yum/src/hooks/useWeight.js
@@ -2,9 +2,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { saveWeight } from '@/services/weightApi';
 import { getUserWeightData } from '@/services/userApi';
+import { useEffect, useState } from 'react';
 
-export const useWeight = (userId) => {
+export const useWeight = (userId, selectedDate) => {
   const queryClient = useQueryClient();
+  // 날짜 선택
+  const [selectedDateModalOpen, setSelectedDateModalOpen] = useState(false);
+  const [selectedDateModal, setSelectedDateModal] = useState(selectedDate);
 
   // 사용자 데이터 불러오기(무게데이터만 가져옴)
   const userData = useQuery({
@@ -19,7 +23,7 @@ export const useWeight = (userId) => {
 
   // 체중 수정(저장)하기
   const saveWeightMutation = useMutation({
-    mutationFn: ({ weight }) => saveWeight({ userId, weight }),
+    mutationFn: ({ weight }) => saveWeight({ userId, weight, date: selectedDateModal }),
     onSuccess: (response) => {
       if (response.success) {
         // 사용자 데이터 쿼리 무효화하여 새로고침
@@ -55,5 +59,32 @@ export const useWeight = (userId) => {
 
     // 몸무게 저장 관련
     saveWeightMutation,
+
+    // 날짜 선택 관련
+    selectedDateModal,
+    setSelectedDateModal,
+    selectedDateModalOpen,
+    setSelectedDateModalOpen,
   };
 };
+
+// 바깥 클릭 감지 훅
+export function useOnClickOutside(ref, handler) {
+  useEffect(() => {
+    const listener = (event) => {
+      // ref가 아직 없거나, 클릭한 게 ref 내부라면 무시
+      if (!ref.current || ref.current.contains(event.target)) {
+        return;
+      }
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+}

--- a/yum-yum/src/pages/home/HomePage.jsx
+++ b/yum-yum/src/pages/home/HomePage.jsx
@@ -31,6 +31,7 @@ import { useHomeStore } from '@/stores/useHomeStore';
 import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
 // 아이디 호출
 import { callUserUid } from '@/utils/localStorage';
+import MyDateField from './modal/MyDateField';
 
 registerLocale('ko', ko);
 
@@ -55,8 +56,14 @@ export default function HomePage() {
     waterData,
     mealData, // 필요한 부분 파싱된 데이터
   } = useHomeStore();
-  const { saveWeightMutation } = useWeight(userId, selectedDate);
-  const { dailyData } = usePageData(userId, selectedDate);
+  const {
+    saveWeightMutation,
+    selectedDateModal,
+    setSelectedDateModal,
+    selectedDateModalOpen,
+    setSelectedDateModalOpen,
+  } = useWeight(userId, selectedDate);
+  const { dailyData, dailyLoading } = usePageData(userId, selectedDate);
   const { userData } = useUserData(userId, selectedDate);
   const { clearFoods, addFood } = useSelectedFoodsStore();
 
@@ -86,7 +93,10 @@ export default function HomePage() {
   // 체중 저장
   const onSubmit = async (data) => {
     try {
-      const saveWeight = saveWeightMutation.mutateAsync({ weight: parseFloat(data.weight) });
+      const saveWeight = saveWeightMutation.mutateAsync({
+        weight: parseFloat(data.weight),
+        date: selectedDateModal,
+      });
 
       await toast.promise(saveWeight, {
         loading: '저장하는 중...',
@@ -116,6 +126,7 @@ export default function HomePage() {
           onOnBoardClick={() => {
             setOnboardOpen(true);
           }}
+          className='shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]'
         />
         {calendarOpen && (
           <div className='absolute z-10 mt-2 left-[120px]'>
@@ -185,6 +196,16 @@ export default function HomePage() {
             btnLabel='확인'
             onBtnClick={handleSubmit(onSubmit)}
           >
+            {/* 날짜 선택 부분 */}
+            <MyDateField
+              register={register}
+              errors={errors}
+              selectedDateModal={selectedDateModal}
+              setSelectedDateModal={setSelectedDateModal}
+              selectedDateModalOpen={selectedDateModalOpen}
+              setSelectedDateModalOpen={setSelectedDateModalOpen}
+            />
+            {/* 몸무게 입력 부분 */}
             <WeightInput register={register} errors={errors} />
           </Modal>
         )}

--- a/yum-yum/src/pages/home/modal/MyDateField.jsx
+++ b/yum-yum/src/pages/home/modal/MyDateField.jsx
@@ -1,0 +1,55 @@
+import React, { useRef } from 'react';
+import { useOnClickOutside } from '../../../hooks/useWeight';
+import DatePicker, { registerLocale } from 'react-datepicker';
+import DateSelector from '../../../components/common/DateSelector';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+registerLocale('ko', ko);
+
+export default function MyDateField({
+  register,
+  errors,
+  selectedDateModal,
+  setSelectedDateModal,
+  selectedDateModalOpen,
+  setSelectedDateModalOpen,
+}) {
+  const wrapperRef = useRef(null);
+
+  // wrapper 바깥을 클릭하면 달력 닫기
+  useOnClickOutside(wrapperRef, () => {
+    setSelectedDateModalOpen(false);
+  });
+
+  return (
+    <div className='flex justify-center mt-4 mb-2 gap-2 items-end'>
+      <DateSelector
+        onCalendarClick={() => setSelectedDateModalOpen(!selectedDateModalOpen)}
+        formattedDate={format(selectedDateModal, 'yyyy년 MM월 dd일', { locale: ko })}
+      />
+      {selectedDateModalOpen && (
+        <div className='absolute z-20 mt-2' ref={wrapperRef}>
+          <DatePicker
+            dateFormat='yyyy.MM.dd'
+            selected={selectedDateModal}
+            onChange={(date) => {
+              setSelectedDateModal(date);
+              setSelectedDateModalOpen(false); // 날짜 선택 후 닫기
+            }}
+            minDate={new Date('2000-01-01')}
+            maxDate={new Date()}
+            locale='ko'
+            inline // 인라인으로 표시
+          />
+        </div>
+      )}
+      {/* 숨겨진 input으로 form에 등록 */}
+      <input
+        type='hidden'
+        {...register('date', { required: '날짜를 입력해주세요' })}
+        value={format(selectedDateModal, 'yyyy-MM-dd')}
+      />
+    </div>
+  );
+}

--- a/yum-yum/src/pages/home/modal/WeightInput.jsx
+++ b/yum-yum/src/pages/home/modal/WeightInput.jsx
@@ -9,11 +9,11 @@ export default function WeightInput({ register, errors }) {
           className='w-28 text-gray-800 text-5xl font-extrabold text-center border-none outline-none no-spinner'
           placeholder='0'
           step='0.1'
-          min='0.0'
+          min='20'
           max='300'
           {...register('weight', {
             required: '체중을 입력해주세요',
-            min: { value: 0.1, message: '올바른 체중을 입력해주세요' },
+            min: { value: 20, message: '올바른 체중을 입력해주세요' },
             max: { value: 300, message: '300kg 이하로 입력해주세요' },
             pattern: {
               value: /^\d+\.?\d*$/,


### PR DESCRIPTION
## 📝 작업 개요
- 지나간 날의 체중 기록이 안되고 당일의 체중만 기록이 가능 했음
- 이전 날의 체중 기록을 추가

## 🔨 작업 내용
- 체중 모달에 날짜(달력으로 선택)을 추가
    - 메인 헤더쪽의 날짜+달력버튼 부분을 컴포넌트로 분리하여 재사용성 높임
-  체중 저장 시, 오늘날짜이면 users의 weight에도 변화를 주고, 아닌경우에는 로그만 남도록 로직 수정

## ✅ 테스트 방법
- 이전 체중 입력 시,
    - 체중 입력 버튼 클릭 
    - 오늘 날짜가 아닌 날짜가 선택되어있는지 확인 후, 체중 입력 -> 저장
    - 현재 체중에 변화가 없는지 확인
- 오늘 날짜 체중 입력 시,
    - 체중 입력 버튼 클릭
    - 오늘 날짜가 선택되어 있는지 확인 후 체중 입력 -> 저장
    - 현재 체중에 변화가 생겼는지 확인 


## 📎 관련 이슈

### 📸 스크린샷(선택)
<img width="508" height="378" alt="스크린샷 2025-09-26 오전 9 16 16" src="https://github.com/user-attachments/assets/d3d693f6-b69e-410b-9dfc-7321a7d0d29b" />



## 🎯 리뷰 요구사항(선택)
