### PR TITLE
[fix] 페이지 전환 시 이메일 체크 유지 및 목표 체중 미설정 시 현재 체중 적용

### DIFF
--- a/yum-yum/src/components/common/DateHeader.jsx
+++ b/yum-yum/src/components/common/DateHeader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import IconNoresult from '@/assets/icons/icon-noresult.svg?react';
+import DateSelector from './DateSelector';
 
 export default function DateHeader({
   date = new Date(),
@@ -14,7 +15,7 @@ export default function DateHeader({
   const formattedDate = format(date, dateFormat, { locale: ko });
 
   return (
-    <div className={`w-full h-16 bg-white shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] ${className}`}>
+    <div className={`w-full h-16 bg-white  ${className}`}>
       {/* Flexbox 컨테이너 */}
       <div className='h-full flex items-center justify-between px-4'>
         {/* 왼쪽 빈 공간 (균형 맞추기 위해) */}
@@ -22,20 +23,7 @@ export default function DateHeader({
 
         {/* 중앙: 날짜 + 캘린더 버튼 */}
         <div className='flex items-center gap-2'>
-          <h1 className='text-black text-xl font-bold whitespace-nowrap'>{formattedDate}</h1>
-
-          {/* 날짜 옆 캘린더 버튼 */}
-          <button
-            className='w-7 h-7 flex items-center justify-center
-                       hover:bg-gray-100 rounded-md transition-colors duration-200
-                       focus:outline-none focus:ring-2 focus:ring-blue-300'
-            onClick={onCalendarClick}
-            aria-label='날짜 선택'
-          >
-            <svg className='w-4 h-4' viewBox='0 0 12 10' fill='currentColor'>
-              <path d='M6 10L0 0h12L6 10z' className='text-emerald-500' />
-            </svg>
-          </button>
+          <DateSelector onCalendarClick={onCalendarClick} formattedDate={formattedDate} />
         </div>
 
         {/* 오른쪽: 온보딩 버튼 */}

--- a/yum-yum/src/components/common/DateSelector.jsx
+++ b/yum-yum/src/components/common/DateSelector.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function DateSelector({ onCalendarClick, formattedDate }) {
+  return (
+    <>
+      <h1 className='text-black text-xl font-bold whitespace-nowrap'>{formattedDate}</h1>
+
+      {/* 날짜 옆 캘린더 버튼 */}
+      <button
+        className='w-7 h-7 flex items-center justify-center
+                       hover:bg-gray-100 rounded-md transition-colors duration-200
+                       focus:outline-none focus:ring-2 focus:ring-blue-300'
+        onClick={onCalendarClick}
+        aria-label='날짜 선택'
+      >
+        <svg className='w-4 h-4' viewBox='0 0 12 10' fill='currentColor'>
+          <path d='M6 10L0 0h12L6 10z' className='text-emerald-500' />
+        </svg>
+      </button>
+    </>
+  );
+}

--- a/yum-yum/src/hooks/useAuth.js
+++ b/yum-yum/src/hooks/useAuth.js
@@ -1,5 +1,5 @@
 // 유저 로그인 & 회원가입 상태 확인 훅
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import toast from 'react-hot-toast';
 import { checkUserEmail, loginUser, registerUser, addUserFireStore } from '../services/userApi';
 import { useUserStore } from '../stores/useUserStore';
@@ -13,7 +13,8 @@ export default function useAuth() {
     loginSuccess, // 로그인 성공 시 (set)
     loginFailure, // 로그인 실패 시 (set)
     logout: logoutStore, // 로그아웃 시(set)
-    checkEmail: checkResult, // 이메일 체크한 결과 값(set)
+    checkEmail,
+    checkResult, // 이메일 체크한 결과 값(set)
     signupSuccess,
     signupFailure,
   } = useUserStore();
@@ -40,7 +41,7 @@ export default function useAuth() {
   );
 
   // 이메일 중복확인
-  const checkEmail = useCallback(async (userId) => {
+  const useCheckEmail = useCallback(async (userId) => {
     setLoading(true);
     clearError();
     const result = await checkUserEmail({ userId });
@@ -77,7 +78,9 @@ export default function useAuth() {
   return {
     isAuthenticated,
     login,
-    checkEmail,
+    useCheckEmail,
     signUp,
+    checkResult,
+    checkEmail,
   };
 }

--- a/yum-yum/src/hooks/useWeight.js
+++ b/yum-yum/src/hooks/useWeight.js
@@ -2,9 +2,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { saveWeight } from '@/services/weightApi';
 import { getUserWeightData } from '@/services/userApi';
+import { useEffect, useState } from 'react';
 
-export const useWeight = (userId) => {
+export const useWeight = (userId, selectedDate) => {
   const queryClient = useQueryClient();
+  // 날짜 선택
+  const [selectedDateModalOpen, setSelectedDateModalOpen] = useState(false);
+  const [selectedDateModal, setSelectedDateModal] = useState(selectedDate);
 
   // 사용자 데이터 불러오기(무게데이터만 가져옴)
   const userData = useQuery({
@@ -19,7 +23,7 @@ export const useWeight = (userId) => {
 
   // 체중 수정(저장)하기
   const saveWeightMutation = useMutation({
-    mutationFn: ({ weight }) => saveWeight({ userId, weight }),
+    mutationFn: ({ weight }) => saveWeight({ userId, weight, date: selectedDateModal }),
     onSuccess: (response) => {
       if (response.success) {
         // 사용자 데이터 쿼리 무효화하여 새로고침
@@ -55,5 +59,32 @@ export const useWeight = (userId) => {
 
     // 몸무게 저장 관련
     saveWeightMutation,
+
+    // 날짜 선택 관련
+    selectedDateModal,
+    setSelectedDateModal,
+    selectedDateModalOpen,
+    setSelectedDateModalOpen,
   };
 };
+
+// 바깥 클릭 감지 훅
+export function useOnClickOutside(ref, handler) {
+  useEffect(() => {
+    const listener = (event) => {
+      // ref가 아직 없거나, 클릭한 게 ref 내부라면 무시
+      if (!ref.current || ref.current.contains(event.target)) {
+        return;
+      }
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+}

--- a/yum-yum/src/pages/auth/signup/pages/SignupStep1.jsx
+++ b/yum-yum/src/pages/auth/signup/pages/SignupStep1.jsx
@@ -11,12 +11,8 @@ export default function SignupStep1({ onNext }) {
   const { control, handleSubmit, watch, setError, clearErrors } = useFormContext();
   const pw = watch('pw');
   const email = watch('email');
-  const { checkEmail } = useAuth();
-
-  // 중복확인 상태 관리
-  const [isEmailChecked, setIsEmailChecked] = useState(false);
-  // 중복확인 한 이메일
-  const [checkedEmail, setCheckedEmail] = useState('');
+  const { useCheckEmail, checkResult, checkEmail } = useAuth();
+  useAuth();
 
   // 성별
   const genderOption = [
@@ -31,7 +27,7 @@ export default function SignupStep1({ onNext }) {
     }
     // console.log('중복 확인:', email);
     try {
-      const result = await checkEmail(email);
+      const result = await useCheckEmail(email);
 
       // checkResult
       if (result.result) {
@@ -40,28 +36,25 @@ export default function SignupStep1({ onNext }) {
           type: 'manual',
           message: result.message,
         });
-        setIsEmailChecked(false);
-        setCheckedEmail('');
+        checkEmail(null);
       } else {
         // 사용가능한 이메일
         clearErrors('email');
         toast.success(result.message);
-        setIsEmailChecked(true);
-        setCheckedEmail(email);
+        checkEmail(email);
       }
     } catch (error) {
       toast.error('이메일 확인 중 오류가 발생했습니다.');
-      setIsEmailChecked(false);
-      setCheckedEmail('');
+      checkEmail(null);
     }
   };
 
   // 이메일이 변경되면 중복확인 상태 초기화
-  useEffect(() => {
-    if (email !== checkedEmail) {
-      setIsEmailChecked(false);
-    }
-  }, [email, checkedEmail]);
+  // useEffect(() => {
+  //   if (email !== checkResult) {
+  //     checkEmail(null);
+  //   }
+  // }, [email, checkResult, checkEmail]);
 
   return (
     <>
@@ -105,10 +98,10 @@ export default function SignupStep1({ onNext }) {
             },
             // 이메일 중복확인 추가
             validate: (value) => {
-              if (value !== checkedEmail) {
+              if (value !== checkResult) {
                 return '이메일 중복확인을 해주세요.';
               }
-              if (!isEmailChecked) {
+              if (!checkResult) {
                 return '이메일 중복확인을 해주세요.';
               }
               return true;

--- a/yum-yum/src/pages/home/HomePage.jsx
+++ b/yum-yum/src/pages/home/HomePage.jsx
@@ -31,6 +31,7 @@ import { useHomeStore } from '@/stores/useHomeStore';
 import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
 // 아이디 호출
 import { callUserUid } from '@/utils/localStorage';
+import MyDateField from './modal/MyDateField';
 
 registerLocale('ko', ko);
 
@@ -55,8 +56,14 @@ export default function HomePage() {
     waterData,
     mealData, // 필요한 부분 파싱된 데이터
   } = useHomeStore();
-  const { saveWeightMutation } = useWeight(userId, selectedDate);
-  const { dailyData } = usePageData(userId, selectedDate);
+  const {
+    saveWeightMutation,
+    selectedDateModal,
+    setSelectedDateModal,
+    selectedDateModalOpen,
+    setSelectedDateModalOpen,
+  } = useWeight(userId, selectedDate);
+  const { dailyData, dailyLoading } = usePageData(userId, selectedDate);
   const { userData } = useUserData(userId, selectedDate);
   const { clearFoods, addFood } = useSelectedFoodsStore();
 
@@ -86,7 +93,10 @@ export default function HomePage() {
   // 체중 저장
   const onSubmit = async (data) => {
     try {
-      const saveWeight = saveWeightMutation.mutateAsync({ weight: parseFloat(data.weight) });
+      const saveWeight = saveWeightMutation.mutateAsync({
+        weight: parseFloat(data.weight),
+        date: selectedDateModal,
+      });
 
       await toast.promise(saveWeight, {
         loading: '저장하는 중...',
@@ -116,6 +126,7 @@ export default function HomePage() {
           onOnBoardClick={() => {
             setOnboardOpen(true);
           }}
+          className='shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]'
         />
         {calendarOpen && (
           <div className='absolute z-10 mt-2 left-[120px]'>
@@ -185,6 +196,16 @@ export default function HomePage() {
             btnLabel='확인'
             onBtnClick={handleSubmit(onSubmit)}
           >
+            {/* 날짜 선택 부분 */}
+            <MyDateField
+              register={register}
+              errors={errors}
+              selectedDateModal={selectedDateModal}
+              setSelectedDateModal={setSelectedDateModal}
+              selectedDateModalOpen={selectedDateModalOpen}
+              setSelectedDateModalOpen={setSelectedDateModalOpen}
+            />
+            {/* 몸무게 입력 부분 */}
             <WeightInput register={register} errors={errors} />
           </Modal>
         )}

--- a/yum-yum/src/pages/home/modal/MyDateField.jsx
+++ b/yum-yum/src/pages/home/modal/MyDateField.jsx
@@ -1,0 +1,55 @@
+import React, { useRef } from 'react';
+import { useOnClickOutside } from '../../../hooks/useWeight';
+import DatePicker, { registerLocale } from 'react-datepicker';
+import DateSelector from '../../../components/common/DateSelector';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+registerLocale('ko', ko);
+
+export default function MyDateField({
+  register,
+  errors,
+  selectedDateModal,
+  setSelectedDateModal,
+  selectedDateModalOpen,
+  setSelectedDateModalOpen,
+}) {
+  const wrapperRef = useRef(null);
+
+  // wrapper 바깥을 클릭하면 달력 닫기
+  useOnClickOutside(wrapperRef, () => {
+    setSelectedDateModalOpen(false);
+  });
+
+  return (
+    <div className='flex justify-center mt-4 mb-2 gap-2 items-end'>
+      <DateSelector
+        onCalendarClick={() => setSelectedDateModalOpen(!selectedDateModalOpen)}
+        formattedDate={format(selectedDateModal, 'yyyy년 MM월 dd일', { locale: ko })}
+      />
+      {selectedDateModalOpen && (
+        <div className='absolute z-20 mt-2' ref={wrapperRef}>
+          <DatePicker
+            dateFormat='yyyy.MM.dd'
+            selected={selectedDateModal}
+            onChange={(date) => {
+              setSelectedDateModal(date);
+              setSelectedDateModalOpen(false); // 날짜 선택 후 닫기
+            }}
+            minDate={new Date('2000-01-01')}
+            maxDate={new Date()}
+            locale='ko'
+            inline // 인라인으로 표시
+          />
+        </div>
+      )}
+      {/* 숨겨진 input으로 form에 등록 */}
+      <input
+        type='hidden'
+        {...register('date', { required: '날짜를 입력해주세요' })}
+        value={format(selectedDateModal, 'yyyy-MM-dd')}
+      />
+    </div>
+  );
+}

--- a/yum-yum/src/pages/home/modal/WeightInput.jsx
+++ b/yum-yum/src/pages/home/modal/WeightInput.jsx
@@ -9,11 +9,11 @@ export default function WeightInput({ register, errors }) {
           className='w-28 text-gray-800 text-5xl font-extrabold text-center border-none outline-none no-spinner'
           placeholder='0'
           step='0.1'
-          min='0.0'
+          min='20'
           max='300'
           {...register('weight', {
             required: '체중을 입력해주세요',
-            min: { value: 0.1, message: '올바른 체중을 입력해주세요' },
+            min: { value: 20, message: '올바른 체중을 입력해주세요' },
             max: { value: 300, message: '300kg 이하로 입력해주세요' },
             pattern: {
               value: /^\d+\.?\d*$/,

--- a/yum-yum/src/services/userApi.js
+++ b/yum-yum/src/services/userApi.js
@@ -135,7 +135,7 @@ const userDocData = (user) => {
     goals: {
       goal: user?.goals,
       targetExercise: user.targetExercise,
-      targetWeight: Number(user.targetWeight),
+      targetWeight: Number(user.targetWeight) || Number(user.weight), // 목표 체중이 없을 때 기존 체중과 동일하게 설정
     },
     height: Number(user.height),
     name: user.name,

--- a/yum-yum/src/stores/useUserStore.js
+++ b/yum-yum/src/stores/useUserStore.js
@@ -10,7 +10,7 @@ export const useUserStore = create(
       isAuthenticated: false, //임시로 true 설정. 기본은 false
       isLoading: false,
       error: null,
-      checkResult: null,
+      checkResult: null, // 이메일 중복확인 결과
 
       // 액션들
       setUser: (user) =>
@@ -58,6 +58,7 @@ export const useUserStore = create(
         set({
           user: null, // 회원가입한 사용자 정보
           userId: uid, // 회원가입한 사용자 ID
+          checkResult: null, // 이메일 중복확인 결과 초기화
           isAuthenticated: true, // 바로 로그인 상태로
           isLoading: false,
           error: null,


### PR DESCRIPTION
## 📝 작업 개요
- 페이지 전환 시 이메일 체크 유지가 되지 않아 이전페이지로 돌아갈 때 한 번더 체크를 해야했음
- 목표체중 미설정 시 0kg으로 뜨는 버그

## 🔨 작업 내용
- 이메일 체크 상태관리를 zustand로 진행
- 유저 정보 저장할 때 `targetWeight` 값이 없는 경우 `weight`값을 저장

## ✅ 테스트 방법
1. 이메일 체크 유지 확인
    - 1페이지 작성 후 2페이지 이동 -> 다시 1페이지 이동(이전버튼 클릭)
    - 이메일 중복체크를 한 번더 해야하는지 확인
2. 체중 미설정 시 홈 화면 확인
    - 체중 유지 선택 후, 목표 체중 미입력 -> 가입
    - 홈 화면에 목표체중과 현재체중이 동일한지 확인 


## 📎 관련 이슈
