### PR TITLE
[fix] 직접 등록 음식 삭제 기능 추가, 탭 변경 시 fetch되던 문제 수정, 검색 결과 없을 시 직접 등록 버튼 추가

### DIFF
--- a/yum-yum/src/components/EmptyState.jsx
+++ b/yum-yum/src/components/EmptyState.jsx
@@ -1,8 +1,15 @@
 import React from 'react';
+// 컴포넌트
+import RoundButton from './button/RoundButton';
 // 아이콘
 import NoResultIcon from '@/assets/icons/icon-noresult.svg?react';
 
-export default function EmptyState({ children = 'Not Found', className = '' }) {
+export default function EmptyState({
+  children = 'Not Found',
+  className = '',
+  btn = false,
+  btnClick,
+}) {
   const isDefault = children === 'Not Found';
   const isStyle = className === '';
 
@@ -17,6 +24,12 @@ export default function EmptyState({ children = 'Not Found', className = '' }) {
       <p className={`text-gray-500 ${isDefault ? 'text-4xl font-bold' : 'text-md font-semibold'}`}>
         {children}
       </p>
+
+      {btn && (
+        <RoundButton size='lg' color='secondary' onClick={btnClick}>
+          {btn}
+        </RoundButton>
+      )}
     </div>
   );
 }

--- a/yum-yum/src/components/modal/ConfirmModal.jsx
+++ b/yum-yum/src/components/modal/ConfirmModal.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react';
+// 컴포넌트
+import BasicButton from '../button/BasicButton';
+
+export default function ConfirmModal({
+  isOpenModal,
+  onCloseModal,
+  onConfirm,
+  title,
+  desc,
+  leftBtnLabel = '취소',
+  rightBtnLabel = '확인',
+}) {
+  // 모달 호출 시 스크롤 막기
+  useEffect(() => {
+    if (!isOpenModal) return;
+    document.body.style.overflow = 'hidden';
+    return () => (document.body.style.overflow = 'auto');
+  }, [isOpenModal]);
+
+  if (!isOpenModal) return null;
+
+  return (
+    <>
+      <div
+        onClick={onCloseModal}
+        className='fixed z-40 left-1/2 bottom-0 -translate-x-1/2 w-full max-w-[500px] h-full bg-black opacity-60'
+      ></div>
+
+      <div className='fixed z-50 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col w-5/6 max-w-[360px] bg-white p-[20px] rounded-3xl'>
+        <div className='flex flex-col gap-[16px] items-center justify-between py-[20px]'>
+          <h2 className='font-bold text-lg'>{title}</h2>
+          {desc && <p className='text-gray-600 text-sm'>{desc}</p>}
+        </div>
+
+        <div className='flex gap-[12px] bg-white pt-[20px]'>
+          <BasicButton onClick={onCloseModal} size='full' variant='line'>
+            {leftBtnLabel}
+          </BasicButton>
+          <BasicButton onClick={onConfirm} size='full'>
+            {rightBtnLabel}
+          </BasicButton>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/yum-yum/src/hooks/useCustomFoods.js
+++ b/yum-yum/src/hooks/useCustomFoods.js
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getCustomFoods, addCustomFood, deleteCustomFood } from '@/services/customFoodsApi';
+
+export const useCustomFoods = (userId) => {
+  const queryClient = useQueryClient();
+
+  // 직접 등록 리스트 불러오기
+  const customFoodData = useQuery({
+    queryKey: ['customFoods', userId],
+    queryFn: () => getCustomFoods(userId),
+    enabled: !!userId,
+    staleTime: 10 * 60 * 1000, // 10분
+    select: (data) => data ?? [],
+  });
+
+  // 직접 등록
+  const addFoodMutation = useMutation({
+    mutationFn: (newFood) => addCustomFood(userId, newFood),
+    onSuccess: () => {
+      // 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['customFoods', userId] });
+    },
+    onError: (error) => {
+      console.error('직접 등록 에러: ', error);
+    },
+  });
+
+  // 삭제
+  const deleteFoodMutation = useMutation({
+    mutationFn: (foodId) => deleteCustomFood(userId, foodId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['customFoods', userId] });
+    },
+    onError: (error) => {
+      console.error('삭제 에러: ', error);
+    },
+  });
+
+  return {
+    foodItems: customFoodData.data ?? [],
+    isLoading: customFoodData.isLoading,
+    isError: customFoodData.isError,
+
+    addFoodMutation,
+    deleteFoodMutation,
+  };
+};

--- a/yum-yum/src/pages/meal/MealPage.jsx
+++ b/yum-yum/src/pages/meal/MealPage.jsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+// 스토어
 import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
-import FrequentlyEatenFood from './page/FrequentlyEatenFood';
-import CustomEntry from './page/CustomEntry';
 // 컴포넌트
 import MealHeader from './component/MealHeader';
 import MealTabs from './component/MealTabs';
 import BasicButton from '@/components/button/BasicButton';
+import FrequentlyEatenFood from './page/FrequentlyEatenFood';
+import CustomEntry from './page/CustomEntry';
 
 const tabItem = [
   { id: 'frequent', label: '최근 먹은 음식' },
@@ -60,7 +61,12 @@ export default function MealPage() {
       />
 
       <MealTabs activeTabId={activeTab} onChange={setActiveTab} tabItem={tabItem} />
-      {activeTab === 'frequent' ? <FrequentlyEatenFood /> : <CustomEntry />}
+      <div className={activeTab === 'frequent' ? 'block' : 'hidden'}>
+        <FrequentlyEatenFood />
+      </div>
+      <div className={activeTab === 'custom' ? 'block' : 'hidden'}>
+        <CustomEntry />
+      </div>
 
       <div className='sticky bottom-0 z-30 block w-full max-w-[500px] p-[20px] bg-white'>
         <BasicButton

--- a/yum-yum/src/pages/meal/component/FoodList.jsx
+++ b/yum-yum/src/pages/meal/component/FoodList.jsx
@@ -4,7 +4,7 @@ import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
 import FoodItem from './FoodItem';
 import FoodDetailModal from './FoodDetailModal';
 
-export default function FoodList({ items = [], variant }) {
+export default function FoodList({ items = [], variant, onRemove }) {
   const { isFoodSelected, addFood, deleteFood } = useSelectedFoodsStore();
   const [openModal, setOpenModal] = useState(false);
   const [selectedFood, setSelectedFood] = useState(null);
@@ -41,7 +41,7 @@ export default function FoodList({ items = [], variant }) {
             variant={variant}
             selected={isFoodSelected(food.id)}
             onSelect={() => handleSelectFood(food)}
-            onRemove={() => handleRemoveFood(food.id)}
+            onRemove={() => (onRemove ? onRemove(food.id) : handleRemoveFood(food.id))}
             onOpenModal={() => handleOpenModal(food)}
           />
         ))}

--- a/yum-yum/src/pages/meal/component/NutritionSection.jsx
+++ b/yum-yum/src/pages/meal/component/NutritionSection.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// 유틸
 import { toNum } from '@/utils/NutrientNumber';
 // 컴포넌트
 import Input from '@/components/common/Input';
@@ -29,41 +30,38 @@ export default function NutritionSection({ register, errors }) {
 
       <div>
         {nutritionFields.map((f) => (
-          <div className='py-[12px]'>
+          <div key={f.id} className='py-[12px]'>
             <div
-              key={f.id}
               className={`flex gap-2 items-center  text-sm ${f.subtle ? 'border-none' : 'first:border-t-0 border-t border-gray-200'}`}
             >
               <label
                 className={`w-full max-w-[226px] ${f.subtle ? 'pl-[20px] text-gray-500' : ''}`}
                 htmlFor={f.id}
               >
-                {f.label}{' '}
+                {f.label}
                 {f.required && <strong className='font-extrabold text-secondary'>*</strong>}
               </label>
 
               <Input
+                id={f.id}
                 type='number'
                 step='any'
                 noSpinner
-                id={f.id}
                 endAdornment={f.unit}
                 placeholder='0'
-                min={0}
-                max={20000}
+                max={10000}
                 status={errors?.nutrient?.[f.id] ? 'error' : 'default'}
                 {...register(`nutrient.${f.id}`, {
                   setValueAs: toNum,
                   ...(f.required && {
                     required: `${f.label}를 입력해주세요.`,
                   }),
-                  min: { value: 0, message: '0 이상 입력하세요' },
-                  max: { value: 20000, message: '20000 이하로 입력하세요' },
+                  max: { value: 10000, message: '10,000 이하로 입력하세요' },
                 })}
               />
             </div>
 
-            {f.required && errors?.nutrient?.[f.id] && (
+            {errors?.nutrient?.[f.id] && (
               <p className='text-[var(--color-error)] text-sm mt-1 text-right'>
                 {errors.nutrient[f.id].message}
               </p>

--- a/yum-yum/src/pages/meal/page/CustomEntry.jsx
+++ b/yum-yum/src/pages/meal/page/CustomEntry.jsx
@@ -1,36 +1,27 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { customFoodsList } from '@/services/customFoodsApi';
+import toast from 'react-hot-toast';
+//훅
+import { useCustomFoods } from '@/hooks/useCustomFoods';
+// 유틸
 import { callUserUid } from '@/utils/localStorage';
 // 컴포넌트
 import EmptyState from '@/components/EmptyState';
 import FoodList from '../component/FoodList';
 // 아이콘
 import SearchIcon from '@/assets/icons/icon-search.svg?react';
+import ConfirmModal from '../../../components/modal/ConfirmModal';
 
 export default function CustomEntry({ selectedIds, onToggleSelect }) {
   const userId = callUserUid(); // 로그인한 유저 uid 가져오기
   const location = useLocation();
   const navigate = useNavigate();
   const { type } = useParams();
-  const [foodItems, setFoodItems] = useState([]);
-  const [loading, setLoading] = useState(true);
   const date = location.state?.date;
-
-  useEffect(() => {
-    const fetchFoods = async () => {
-      try {
-        const data = await customFoodsList(userId);
-        setFoodItems(data);
-      } catch (error) {
-        console.error('불러오기 실패:', error);
-        throw error;
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchFoods();
-  }, []);
+  const { foodItems, deleteFoodMutation } = useCustomFoods(userId);
+  const [isEditing, setIsEditing] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [targetFoodId, setTargetFoodId] = useState(null);
 
   // 직접 등록 폼으로 이동
   const handleCustomEntry = () => {
@@ -39,32 +30,73 @@ export default function CustomEntry({ selectedIds, onToggleSelect }) {
     });
   };
 
+  // 편집 토글
+  const handleToggleEdit = () => {
+    setIsEditing((prev) => !prev);
+  };
+
+  // 삭제 아이콘 클릭 시
+  const handleDeleteCustom = (foodId) => {
+    setTargetFoodId(foodId);
+    setConfirmOpen(true);
+  };
+
+  // 컨펌창에서 삭제 버튼 눌렀을떄
+  const handleConfirmDelete = async () => {
+    if (!targetFoodId) return;
+
+    try {
+      await toast.promise(deleteFoodMutation.mutateAsync(targetFoodId), {
+        loading: '삭제 중...',
+        success: '삭제 되었습니다!',
+        error: '삭제 실패',
+      });
+    } catch (error) {
+      console.error('직접 등록 실패', error);
+    } finally {
+      setConfirmOpen(false);
+      setTargetFoodId(null);
+    }
+  };
+
   return (
     <div className='flex flex-col h-full'>
-      <div className='sticky top-[118px] z-30 flex justify-between items-center px-5 py-3 bg-gray-50'>
+      <div className='sticky top-[118px] z-30'>
         {/* 직접 등록 버튼 */}
-        <div className='flex gap-2 items-center'>
-          <div className='flex items-center justify-center'>
-            <SearchIcon />
+        <div className='flex justify-between items-center px-5 py-3 bg-gray-50'>
+          <div className='flex gap-2 items-center'>
+            <div className='flex items-center justify-center'>
+              <SearchIcon />
+            </div>
+            <p className='text-gray-700'>찾는 음식이 없나요?</p>
           </div>
-          <p className='text-gray-700'>찾는 음식이 없나요?</p>
+
+          <button
+            onClick={handleCustomEntry}
+            className='bg-secondary rounded-full text-white font-bold text-sm px-4 py-2'
+          >
+            직접 등록
+          </button>
         </div>
 
-        <button
-          onClick={handleCustomEntry}
-          className='bg-secondary rounded-full text-white font-bold text-sm px-4 py-2'
-        >
-          직접 등록
-        </button>
+        {foodItems.length > 0 && (
+          <div className='sticky top-[118px] flex items-center justify-between pt-4 px-5 bg-white'>
+            <h4 className='font-extrabold'>{isEditing ? '직접 등록 편집' : '직접 등록'}</h4>
+            <button onClick={handleToggleEdit} className='text-gray-500'>
+              {isEditing ? '완료' : '편집'}
+            </button>
+          </div>
+        )}
       </div>
 
       <div className='flex flex-col min-h-[calc(100vh-266px)]'>
         <div className='flex-1 px-[20px]'>
           {foodItems.length > 0 ? (
             <FoodList
-              variant='select'
+              variant={isEditing ? 'delete' : 'select'}
               selectedIds={selectedIds}
               onToggleSelect={onToggleSelect}
+              onRemove={isEditing ? handleDeleteCustom : undefined}
               items={foodItems}
             />
           ) : (
@@ -72,6 +104,18 @@ export default function CustomEntry({ selectedIds, onToggleSelect }) {
           )}
         </div>
       </div>
+
+      {/* 삭제 확인 모달 */}
+      <ConfirmModal
+        isOpenModal={confirmOpen}
+        s
+        onCloseModal={() => setConfirmOpen(false)}
+        title='음식을 삭제하시겠어요?'
+        desc='리스트에서 삭제됩니다.'
+        leftBtnLabel='취소'
+        RightBtnLabel='삭제'
+        onConfirm={handleConfirmDelete}
+      />
     </div>
   );
 }

--- a/yum-yum/src/pages/meal/page/CustomEntryForm.jsx
+++ b/yum-yum/src/pages/meal/page/CustomEntryForm.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import toast from 'react-hot-toast';
-import { addCustomFood } from '@/services/customFoodsApi';
 import { useForm } from 'react-hook-form';
+import toast from 'react-hot-toast';
+// 훅
+import { useCustomFoods } from '@/hooks/useCustomFoods';
+// 유틸
 import { callUserUid } from '@/utils/localStorage';
 // 컴포넌트
 import MealHeader from '../component/MealHeader';
@@ -15,6 +17,9 @@ export default function CustomEntryForm() {
   const location = useLocation();
   const navigate = useNavigate();
   const selectedDate = location.state?.date || new Date();
+  const type = location.state?.type;
+  const { addFoodMutation } = useCustomFoods(userId);
+
   const {
     register,
     handleSubmit,
@@ -47,13 +52,15 @@ export default function CustomEntryForm() {
 
   const onSubmit = async (data) => {
     try {
-      await addCustomFood(userId, data);
-      toast.success('등록 되었습니다!');
+      await toast.promise(addFoodMutation.mutateAsync(data), {
+        loading: '등록 중...',
+        success: '등록 되었습니다!',
+        error: '등록 실패',
+      });
       reset();
-      navigate(-1, { state: { date: selectedDate } });
+      navigate(`/meal/${type}`, { state: { date: selectedDate, type: type } });
     } catch (error) {
-      alert('등록 실패');
-      console.error(error);
+      console.error('직접 등록 실패', error);
     }
   };
 
@@ -100,7 +107,7 @@ export default function CustomEntryForm() {
                 {...register('servingSize', {
                   required: '내용량을 입력해주세요.',
                   min: { value: 0, message: '0 이상 입력해주세요' },
-                  max: { value: 10000, message: '10000 이하로 입력해주세요' },
+                  max: { value: 10000, message: '10,000 이하로 입력해주세요' },
                 })}
               />
 

--- a/yum-yum/src/pages/meal/page/FoodSearchResults.jsx
+++ b/yum-yum/src/pages/meal/page/FoodSearchResults.jsx
@@ -1,16 +1,20 @@
 // 음식 검색 시, 검색 결과 확인 화면
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+// 스토어
+import { useSearchFoodStore } from '@/stores/useSearchFoodStore';
+import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
+// 훅
+import { useSearchFoodData } from '@/hooks/useSearchFoodData';
+// 컴포넌트
 import BasicButton from '@/components/button/BasicButton';
 import EmptyState from '@/components/EmptyState';
 import FoodList from '../component/FoodList';
 import MealHeader from '../component/MealHeader';
-import { useSearchFoodStore } from '../../../stores/useSearchFoodStore';
-import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
-import { useSearchFoodData } from '../../../hooks/useSearchFoodData';
 
 export default function FoodSearchResultsPage() {
   const location = useLocation();
+  const navigate = useNavigate();
   const searchItem = location.state?.searchInputValue; // 검색하는 음식 이름
   const type = location.state?.type; // 추가 타입
   const date = location.state?.date; // 추가 타입
@@ -18,12 +22,10 @@ export default function FoodSearchResultsPage() {
   const { selectedFoods, clearFoods } = useSelectedFoodsStore();
   const { searchData, isLoading, isError, refetch } = useSearchFoodData(searchItem);
   const [searchInputValue, setSearchInputValue] = useState(searchItem || '');
-  const navigate = useNavigate();
 
   // 음식 검색
   useEffect(() => {
     if (searchData) {
-      // console.log('검색결과:', searchData);
       setSearchFoodResults(searchData);
     }
   }, [searchData]);
@@ -35,11 +37,17 @@ export default function FoodSearchResultsPage() {
 
   // 돋보기 아이콘 클릭, 엔터
   const handleSearchSubmit = () => {
-    // console.log(searchInputValue);
     // 같은 페이지로 navigate하되 검색어를 새로 전달
     navigate(`/meal/search`, {
       state: { searchInputValue: searchInputValue, type: type, date: date },
       replace: false,
+    });
+  };
+
+  // 직접 등록 버튼
+  const handleCustomEntry = () => {
+    navigate(`/meal/custom`, {
+      state: { type, date },
     });
   };
 
@@ -58,24 +66,25 @@ export default function FoodSearchResultsPage() {
         onChange={onSearchChange}
         handleSearchSubmit={handleSearchSubmit}
       />
+
       <div>
         <div className='flex flex-col min-h-[calc(100vh-148px)]'>
           <div className='flex-1 px-[20px]'>
             {foodItems?.length > 0 ? (
-              <FoodList
-                variant='select'
-                // selectedIds={selectedIds}
-                // onToggleSelect={handleToggleSelect}
-                items={foodItems}
-              />
+              <FoodList variant='select' items={foodItems} />
             ) : (
-              <EmptyState className='min-h-[calc(100vh-148px)]'>
+              <EmptyState
+                className='min-h-[calc(100vh-148px)]'
+                btn='직접 등록'
+                btnClick={handleCustomEntry}
+              >
                 검색한 음식 결과가 없어요.
               </EmptyState>
             )}
           </div>
         </div>
       </div>
+
       <div className='sticky bottom-0 z-30 block w-full max-w-[500px] p-[20px] bg-white'>
         <BasicButton
           size='full'

--- a/yum-yum/src/services/customFoodsApi.js
+++ b/yum-yum/src/services/customFoodsApi.js
@@ -1,4 +1,5 @@
 import { firestore } from '@/services/firebase';
+import { callUserUid } from '@/utils/localStorage';
 import {
   collection,
   doc,
@@ -7,9 +8,11 @@ import {
   orderBy,
   query,
   getDocs,
+  deleteDoc,
 } from 'firebase/firestore';
-import { callUserUid } from '@/utils/localStorage';
+
 const userId = callUserUid(); // 로그인한 유저 uid 가져오기
+
 // 직접 입력 음식 등록
 export const addCustomFood = async (userId, newFoodData) => {
   try {
@@ -32,9 +35,8 @@ export const addCustomFood = async (userId, newFoodData) => {
 };
 
 // 집접 입력 음식 조회
-export const customFoodsList = async () => {
+export const getCustomFoods = async () => {
   try {
-    // const customFoodsCol = collection(firestore, 'users', userId, 'customFoods');
     const customFoodsCol = collection(firestore, 'users', userId, 'customFoods');
     const q = query(customFoodsCol, orderBy('createdAt', 'desc'));
     const querySnapshot = await getDocs(q);
@@ -47,7 +49,6 @@ export const customFoodsList = async () => {
         makerName: data?.makerName ?? '',
         foodSize: data?.servingSize ?? 0,
         foodUnit: data?.servingUnit ?? 'g',
-        // kcal: data.nutrient.kcal,
 
         nutrient: {
           kcal: data?.nutrient?.kcal ?? null,
@@ -73,4 +74,11 @@ export const customFoodsList = async () => {
     console.error('불러오기 중 오류 발생:', error);
     throw error;
   }
+};
+
+// 직접 입력 음식 삭제
+export const deleteCustomFood = async (userId, foodId) => {
+  const customFoodDoc = doc(firestore, 'users', userId, 'customFoods', foodId);
+  await deleteDoc(customFoodDoc);
+  return foodId;
 };


### PR DESCRIPTION
## 📝 작업 개요
- 직접 등록 음식 삭제 기능 추가
- 탭 변경 시 fetch되던 문제 수정
- 검색 결과 없을 시 직접 등록 버튼 추가

## 🔨 작업 내용
- EmptyState 컴포넌트 버튼 추가
- 검색 결과 없을 시 직접 등록 버튼 추가
- 직접 등록 음식 삭제 기능 추가
- 직접 등록 react-query로 변경
- 탭 변경할때 마다 fetch되던 문제 수정
- ComfrimModal component 추가

## ✅ 테스트 방법
### 편집 버튼 클릭 > 리스트 삭제 아이콘 클릭 > 컨펌 모달창 > 삭제 > 리스트 및 파이어 스토어에서 삭제
<img width="495" height="402" alt="20250926_133149" src="https://github.com/user-attachments/assets/22d84ba7-7809-4725-acef-8e2412809383" />
<img width="493" height="403" alt="20250926_133126" src="https://github.com/user-attachments/assets/4c2099e0-8a25-4351-93dc-7823a8e8b6e0" />
<img width="495" height="909" alt="20250926_133209" src="https://github.com/user-attachments/assets/fbac52c8-5b1a-4f25-b160-7ebc74212fd9" />

### 검색 결과 없을 시 직접 등록 버튼 > 직접 입력 폼
<img width="494" height="907" alt="20250926_133223" src="https://github.com/user-attachments/assets/8628778f-f7c3-435c-bba2-5550d6538652" />



## 📎 관련 이슈

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)