### PR TITLE
[fix] 식단 삭제 시 해당 요일 모든 식단 삭제 이슈 수정

### DIFF
--- a/yum-yum/src/pages/meal/page/TotalMeal.jsx
+++ b/yum-yum/src/pages/meal/page/TotalMeal.jsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { firestore } from '@/services/firebase';
-import { deleteDoc, doc, Timestamp } from 'firebase/firestore';
+import { deleteField, doc, Timestamp, updateDoc } from 'firebase/firestore';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import toast from 'react-hot-toast';
@@ -63,11 +63,13 @@ export default function TotalMeal({ defaultDate = new Date(), dateFormat = 'MM�
   const handleSubmitRecord = async () => {
     try {
       const formattedSaveDate = format(selectedDate, 'yyyy-MM-dd');
+      const mealRef = doc(firestore, 'users', userId, 'meal', formattedSaveDate);
 
-      // 삭제 처리
+      // 해당 type만 삭제 처리
       if (foods.length === 0) {
-        const mealRef = doc(firestore, 'users', userId, 'meal', formattedSaveDate);
-        await deleteDoc(mealRef);
+        await updateDoc(mealRef, {
+          [`meals.${type}`]: deleteField(),
+        });
 
         // 캐시 무효화
         queryClient.invalidateQueries(['dailyData', userId, formattedSaveDate]);


### PR DESCRIPTION
## 📝 작업 개요
- 식단 삭제 시 해당 요일 모든 식단 삭제 이슈 수정

## 🔨 작업 내용
- 식단 삭제 시 해당 요일이 모두 삭제 되어 delteDoc > updateDoc 으로 변경
```rfc
await updateDoc(mealRef, {
    [`meals.${type}`]: deleteField(),
});
```

## ✅ 테스트 방법
- 아침, 점심 식단 등록 후 점심 식단 음식 모두 빼고 저장 시 점심 식단만 비워지는지 확인

## 📎 관련 이슈

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)