### PR TITLE
[fix] 체중 변화 추이 리포트를 위한 문서 구조 수정

### DIFF
--- a/yum-yum/src/services/weightApi.js
+++ b/yum-yum/src/services/weightApi.js
@@ -27,6 +27,8 @@ export async function saveWeight({ userId, weight, date }) {
     const inputDate = getTodayKey(new Date(date));
     // 오늘 날짜
     const today = getTodayKey(new Date());
+    // YYYY-MM
+    const monthly = inputDate.substring(0, 7); // yyyy-mm
     // users의 현재 체중 업데이트
     if (inputDate == today) {
       const userRef = doc(firestore, 'users', userId);
@@ -40,19 +42,60 @@ export async function saveWeight({ userId, weight, date }) {
     };
 
     // weight 문서 업데이트 혹은 추가
-    const weightDocRef = doc(firestore, 'users', userId, 'weight', inputDate);
+    const weightDocRef = doc(firestore, 'users', userId, 'weight', monthly);
 
     // 문서 존재 여부 확인
     const docSnapshot = await getDoc(weightDocRef);
 
     if (docSnapshot.exists()) {
-      // 존재하는경우 업데이트
-      batch.update(weightDocRef, { changes: arrayUnion(newChange), updatedAt: serverTimestamp() });
+      // 존재하는경우, date가 최신날짜가 아닌경우에만 업데이트
+      const oldDate = docSnapshot.data().date; // ex. "2025-09-24"
+      // oldDate ≥ inputDate 이면 이미 최신 데이터가 있으므로 업데이트 스킵
+      if (oldDate <= inputDate) {
+        // inputDate가 더 최신일 때만 lastchanges 업데이트
+        batch.update(monthDocRef, {
+          date: inputDate,
+          lastchanges: {
+            weight,
+            timestamp: new Date(),
+          },
+          updatedAt: serverTimestamp(),
+        });
+      } else {
+        console.log('더 최신 데이터가 이미 있어서 월간 문서 업데이트를 스킵합니다.');
+      }
     } else {
       // 존재하지 않는 경우 새로 만듦
       batch.set(weightDocRef, {
         date: inputDate,
-        changes: [newChange],
+        lastchanges: newChange,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+    }
+
+    // weight log 남기기
+    const weightLogsDocRef = doc(
+      firestore,
+      'users',
+      userId,
+      'weight',
+      monthly,
+      'weightLogs',
+      inputDate,
+    );
+    // 문서 존재 여부 확인
+    const docSnapshot2 = await getDoc(weightLogsDocRef);
+
+    if (docSnapshot2.exists()) {
+      batch.update(weightLogsDocRef, {
+        lastchanges: newChange,
+        updatedAt: serverTimestamp(),
+      });
+    } else {
+      batch.set(weightLogsDocRef, {
+        date: inputDate,
+        lastchanges: newChange,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
       });


### PR DESCRIPTION
## 📝 작업 개요
- 체중 변화 추이 리포트를 위한 문서 구조 수정

## 🔨 작업 내용
- 기존 구조
     - 선택한 날짜에 체중을 여러번입력할 때 전부 저장하는 형식으로 진행
     - weight 컬랙션에 일자로 구분하여 문서 저장
- 수정 한 구조
- weight : 2025-09(yyyy-mm)
```json
{
  _id: ObjectId,
  date: Date, // YYYY-MM-DD 형태(제일 최신데이터로 유지해야함)
  lastChange: {
    weight: Number,
    timestamp: Date
  },
  createdAt: Date,
  updatedAt: Date
}
```
- weightLogs : 2025-09-29(yyyy-mm-dd)
```json
// 2025-09-01(새로운컬랙션) weightLogs
{
  _id: ObjectId,
  date: Date, // YYYY-MM-DD 형태
  lastChange: { // 해당날짜 마지막 업데이트 내용만 남김(덮어쓰기)
    weight: Number,
    timestamp: Date
  },
  createdAt: Date,
  updatedAt: Date
}
```

## ✅ 테스트 방법
- 체중 입력 : 오늘날짜나 여러 날짜 입력 후 firestore에서 weight부분 확인

## 📎 관련 이슈
#117 
> 추이를 나타낼 때, 기존방식은 쿼리 호출 시 쓸모없는 데이터들까지 전부 호출을 해서 비용이 많이 발생을 했지만, 이렇게 수정함으로써 비용 발생을 최소화 함

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)
