### PR TITLE
[Fix] 식단이 없는경우 Ai 호출 시 버그 수정

### DIFF
--- a/yum-yum/src/hooks/useMeals.js
+++ b/yum-yum/src/hooks/useMeals.js
@@ -1,10 +1,9 @@
-// ai 리포트에서 사용될 식단 가져오는 훅
-
 import { useQuery } from '@tanstack/react-query';
 import { getSelectedData } from '../services/nutritionAnalysis';
 import { parseMeals } from '../utils/mainDataParser';
 import { format } from 'date-fns';
 
+// ai 리포트에서 사용될 식단 가져오는 훅
 export function useMeals(userId, selectedDate, type) {
   return useQuery({
     queryKey: ['aireport-meals', userId, format(selectedDate, 'yyyy-MM-dd'), type],
@@ -16,8 +15,8 @@ export function useMeals(userId, selectedDate, type) {
       }
       return parseMeals(rawMeals, selectedDate);
     },
-    staleTime: 1000 * 60 * 5,
-    cacheTime: 1000 * 60 * 30,
+    staleTime: 1000 * 60 * 10, // 10분
+    cacheTime: 1000 * 60 * 30, // 30분
     retry: 1,
     enabled: !!userId && !!selectedDate && !!type,
   });

--- a/yum-yum/src/hooks/useMeals.js
+++ b/yum-yum/src/hooks/useMeals.js
@@ -9,9 +9,9 @@ export function useMeals(userId, selectedDate, type) {
     queryKey: ['aireport-meals', userId, format(selectedDate, 'yyyy-MM-dd'), type],
     queryFn: () => getSelectedData(userId, selectedDate, type),
     select: (rawMeals) => {
-      if (rawMeals.error) {
+      if (!rawMeals.success) {
         //식단 호출 에러시 그냥 리턴
-        return;
+        return rawMeals;
       }
       return parseMeals(rawMeals, selectedDate);
     },

--- a/yum-yum/src/hooks/useMeals.js
+++ b/yum-yum/src/hooks/useMeals.js
@@ -9,7 +9,13 @@ export function useMeals(userId, selectedDate, type) {
   return useQuery({
     queryKey: ['aireport-meals', userId, format(selectedDate, 'yyyy-MM-dd'), type],
     queryFn: () => getSelectedData(userId, selectedDate, type),
-    select: (rawMeals) => parseMeals(rawMeals, selectedDate),
+    select: (rawMeals) => {
+      if (rawMeals.error) {
+        //식단 호출 에러시 그냥 리턴
+        return;
+      }
+      return parseMeals(rawMeals, selectedDate);
+    },
     staleTime: 1000 * 60 * 5,
     cacheTime: 1000 * 60 * 30,
     retry: 1,

--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -54,13 +54,6 @@ export const useNutritionAnalysis = (
     refetchOnMount: true,
     retry: (count, err) => count < 3 && err.type === 'RESOURCE_EXHAUSTED',
     retryDelay: (n) => Math.min(1000 * 2 ** n, 30_000),
-    onSuccess: (data) => {
-      // generateNutritionAnalysis 에서 성공적으로 생성된 데이터가 오면
-      // react-query 캐시에 함께 세팅
-      if (!hasExecutedInTimePeriod(today, periodKey, dataHash)) {
-        markExecutedInTimePeriod(today, periodKey, dataHash);
-      }
-    },
   });
 
   return {

--- a/yum-yum/src/hooks/useNutritionAnalysis.js
+++ b/yum-yum/src/hooks/useNutritionAnalysis.js
@@ -5,7 +5,13 @@ import { generateDataHash } from '../utils/hashUtils';
 import { getTodayKey } from '../utils/dateUtils';
 import { hasExecutedInTimePeriod, markExecutedInTimePeriod } from '@/utils/localStorage';
 
-export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTimePeriod, searchType) => {
+export const useNutritionAnalysis = (
+  userId,
+  meals = {},
+  selectedDate,
+  currentTimePeriod,
+  searchType,
+) => {
   const queryClient = useQueryClient();
   const dataHash = generateDataHash(meals);
   const today = getTodayKey(selectedDate);
@@ -35,13 +41,13 @@ export const useNutritionAnalysis = (userId, meals = {}, selectedDate, currentTi
         return cached;
       }
 
-      console.log('db에 없거나 아직 한번도 안 실행한 경우 AI 생성');
+      // console.log('db에 없거나 아직 한번도 안 실행한 경우 AI 생성');
       // 3. DB에 없거나 아직 한번도 안 실행한 경우 AI 생성
       const fresh = await generateNutritionAnalysis(userId, meals, dataHash);
       return fresh;
     },
     // enabled: false,
-    enabled: !!periodKey && !!meals.date,
+    enabled: !!periodKey && !!meals, // meals 객체가 완전 비어있으면 작동xx
     staleTime: 1000 * 60 * 60 * 24,
     gcTime: 1000 * 60 * 60 * 24 * 7,
     refetchOnWindowFocus: false,

--- a/yum-yum/src/services/nutritionAnalysis.js
+++ b/yum-yum/src/services/nutritionAnalysis.js
@@ -92,7 +92,7 @@ export async function generateNutritionAnalysisWithBackoff(meals) {
 // 1번: 호출한 AI Api는 DB에서 호출
 export async function fetchAIResultWithCache(userId, meals, dataHash) {
   if (!meals?.date || !meals?.type || !dataHash) {
-    return;
+    return { success: false, text: '식단 데이터가 없습니다. 식단을 입력 후 다시 시도해주세요.' };
   }
   try {
     const aiRef = collection(firestore, 'users', userId, 'aimessage');
@@ -157,7 +157,7 @@ export async function getSelectedData(userId, selectedDate, type) {
     if (querySnapshot.empty || querySnapshot.size === 0 || querySnapshot.docs.length === 0) {
       return {
         success: false,
-        error: '식단 데이터가 없습니다. 식단을 입력 후 다시 시도해주세요.',
+        text: '식단 데이터가 없습니다. 식단을 입력 후 다시 시도해주세요.',
       };
     }
     const data = querySnapshot.docs.map((docSnap) => ({

--- a/yum-yum/src/services/nutritionAnalysis.js
+++ b/yum-yum/src/services/nutritionAnalysis.js
@@ -1,15 +1,5 @@
 // AI 호출 API
-import {
-  addDoc,
-  collection,
-  getDoc,
-  getDocs,
-  limit,
-  orderBy,
-  query,
-  setDoc,
-  where,
-} from 'firebase/firestore';
+import { addDoc, collection, getDocs, limit, orderBy, query, where } from 'firebase/firestore';
 import { firestore, model } from './firebase';
 import { endOfMonth, endOfWeek, format, startOfMonth, startOfWeek } from 'date-fns';
 import { getCurrentTimePeriod } from '../data/timePeriods';
@@ -50,8 +40,8 @@ export async function generateNutritionAnalysis(userId, meals, dataHash) {
       success: true,
     };
   }
-  const prompt = systemPrompt + createPrompt(meals);
   try {
+    const prompt = systemPrompt + createPrompt(meals);
     // model 호출 및 prompt start
     const result = await model.generateContent(prompt);
     const response = result.response;

--- a/yum-yum/src/services/userApi.js
+++ b/yum-yum/src/services/userApi.js
@@ -74,11 +74,18 @@ export async function loginUser({ userid, password }) {
       user,
     };
   } catch (error) {
-    //throw new Error(error); // debug용
-    return {
-      success: false,
-      error: error.message,
-    };
+    // throw new Error(error); // debug용
+    if (error.code === 'auth/invalid-credential') {
+      return {
+        success: false,
+        error: '아이디 혹은 비밀번호가 일치하지 않습니다.',
+      };
+    } else {
+      return {
+        success: false,
+        error: error.message,
+      };
+    }
   }
 }
 


### PR DESCRIPTION
## 📝 작업 개요
- useMeals에서   select: (rawMeals) => parseMeals(rawMeals, selectedDate), 이 부분에서 식단이 없을 때, data가 null이 떠 파싱할 때 이슈가 나타남
- 식단 입력이 안된 경우 AI 호출 시, 예외처리를 해두지 않아 예상 외의 작용을 함

## 🔨 작업 내용
- `useMeals`
    - `!rawMeals.success`: 값이 없는 경우 예외처리
    -  staleTime 10분으로 늘림
- `useNutritionAnalysis`
    -  `enabled` 수정 : meals 객체가 완전 비어있으면 작동xx
    - `onSuccess` 작동을 하지 않는 것을 확인. 제거
- `nutritionAnalysis`
    -  식단이 없어서 api 호출을 안한 경우, success는 true로 리턴
    - prompt 생성 함수 호출부분 `trycatch` 내부로 이동
    - 식단 데이터 검색하는 함수에서 `if (querySnapshot.empty || querySnapshot.size === 0 || querySnapshot.docs.length === 0)` 조건문 추가
- `userApi`
    - 로그인 시 예외처리: 에러메시지 분기 처리
    
## ✅ 테스트 방법
- AI 리포트 호출 전, 식단입력을 하지 않은채 1회 호출 
    - 아직 AI 코치의 분석 결과가 없습니다. 라고 뜸
- 식단 입력 후 AI 리포트 호출
    - AI 리포트 결과 도출

## 📎 관련 이슈


### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항(선택)
- `아직 AI 코치의 분석 결과가 없습니다.`라는 안내메시지 이외에 다른 좋은 문구 있나요..?
    - 식단 데이터가 없는경우 ai 호출하는 리액트 쿼리를 호출하지 않아 해당 부분에 미리 지정해둔 문구가 보임
