### PR TITLE
 [refactor] 홈에서 사용되는 훅 분리, api 분리 작업

### DIFF
--- a/yum-yum/src/hooks/useDailyMeal.js
+++ b/yum-yum/src/hooks/useDailyMeal.js
@@ -14,7 +14,7 @@ export const useDailyMeal = (userId, date) => {
     },
     onSuccess: () => {
       toast.success('식단 기록이 완료 되었어요!');
-      queryClient.invalidateQueries({ queryKey: ['dailyData', userId, date] });
+      queryClient.invalidateQueries({ queryKey: ['daily-meal-data', userId, date] });
     },
     onError: (error) => {
       toast.error('식단 기록 실패!');
@@ -32,7 +32,7 @@ export const useDailyMeal = (userId, date) => {
     },
     onSuccess: () => {
       toast.success('식단 기록이 삭제 되었어요!');
-      queryClient.invalidateQueries({ queryKey: ['dailyData', userId, date] });
+      queryClient.invalidateQueries({ queryKey: ['daily-meal-data', userId, date] });
     },
     onError: (error) => {
       toast.error('식단 삭제 실패!');

--- a/yum-yum/src/hooks/useMainPageData.js
+++ b/yum-yum/src/hooks/useMainPageData.js
@@ -28,7 +28,7 @@ export const usePageData = (userId, selectedDate) => {
     targetCalories,
     currentWeight,
     goalWeight,
-    mealDataOrigin: mealOrigin.mealData,
+    mealDataOrigin: mealOrigin?.mealData,
   };
 };
 

--- a/yum-yum/src/hooks/useMainPageData.js
+++ b/yum-yum/src/hooks/useMainPageData.js
@@ -1,28 +1,72 @@
 // main페이지 데이터 상태, 호출 훅
 import { useQuery } from '@tanstack/react-query';
-import { getDailyData } from '@/services/dailyDataApi';
+import { getDailyData, getDailyMeal, getDailyWater } from '@/services/dailyDataApi';
 import { getTodayKey } from '@/utils/dateUtils';
+import { useHomeStore } from '@/stores/useHomeStore';
+import { useEffect } from 'react';
+import { useHomeUserHook } from './useUser';
 
 export const usePageData = (userId, selectedDate) => {
-  // 선택된 날짜의 물, 식사 데이터
-  const dailyDataQuery = useQuery({
-    queryKey: ['dailyData', userId, getTodayKey(selectedDate)],
-    queryFn: () => getDailyData(userId, selectedDate),
-    select: (resp) => resp.data,
-    staleTime: 1 * 60 * 1000, // 1분
-    // staleTime: 30 * 1000, // 30초
+  const { setWaterData, setMealData } = useHomeStore();
+  const { waterData: waterOrigin } = useDailyWaterData(userId, selectedDate);
+  const { mealData: mealOrigin } = useDailyMealData(userId, selectedDate);
+  const { userData } = useHomeUserHook(userId);
+
+  useEffect(() => {
+    if (waterOrigin) setWaterData(waterOrigin, userData);
+  }, [waterOrigin, setWaterData]);
+
+  useEffect(() => {
+    if (mealOrigin) setMealData(mealOrigin);
+  }, [mealOrigin, setMealData]);
+
+  // store 에서 꺼내서 사용
+  const { waterData, mealData, targetCalories, currentWeight, goalWeight } = useHomeStore();
+  return {
+    waterData,
+    mealData,
+    targetCalories,
+    currentWeight,
+    goalWeight,
+    mealDataOrigin: mealOrigin.mealData,
+  };
+};
+
+// 선택한 날 하루의 전체 식단 데이터
+export const useDailyMealData = (userId, selectedDate) => {
+  const dailyMealData = useQuery({
+    queryKey: ['daily-meal-data', userId, getTodayKey(selectedDate)],
+    queryFn: () => getDailyMeal(userId, selectedDate),
+    staleTime: 5 * 60 * 1000, // 5분
     enabled: !!userId && !!selectedDate,
   });
 
-  // 수동 갱신 함수
-  const refetchDaily = () => dailyDataQuery.refetch();
+  const refetchMealData = () => dailyMealData.refetch();
 
   return {
-    // 일일 데이터
-    dailyData: dailyDataQuery.data,
-    dailyLoading: dailyDataQuery.isLoading,
+    mealData: dailyMealData.data,
+    mealLoading: dailyMealData.isLoading,
+    mealError: dailyMealData.error,
 
-    // 수동 갱신 (일일 데이터)
-    refetchDaily,
+    refetchMealData,
+  };
+};
+
+// 선택한 날 하루의 전체 물 데이터
+export const useDailyWaterData = (userId, selectedDate) => {
+  const dailyWaterData = useQuery({
+    queryKey: ['daily-water-data', userId, getTodayKey(selectedDate)],
+    queryFn: () => getDailyWater(userId, selectedDate),
+    staleTime: 5 * 60 * 1000, // 5분
+    enabled: !!userId && !!selectedDate,
+  });
+  const refetchWaterData = () => dailyWaterData.refetch();
+
+  return {
+    waterData: dailyWaterData.data,
+    waterLoading: dailyWaterData.isLoading,
+    waterError: dailyWaterData.error,
+
+    refetchWaterData,
   };
 };

--- a/yum-yum/src/hooks/useUser.js
+++ b/yum-yum/src/hooks/useUser.js
@@ -1,8 +1,10 @@
 // 사용자 데이터 쿼리 훅
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getUserData } from '../services/userApi';
+import { useHomeStore } from '../stores/useHomeStore';
 
-export const useUserData = (userId, selectedDate) => {
+const useUserData = (userId) => {
   // 사용자 데이터 불러오기
   const userQuery = useQuery({
     queryKey: ['user', userId],
@@ -15,5 +17,17 @@ export const useUserData = (userId, selectedDate) => {
   return {
     userData: userQuery.data,
     userLoading: userQuery.isLoading,
+  };
+};
+
+export const useHomeUserHook = (userId) => {
+  const { calcuateCalories } = useHomeStore();
+  const { userData } = useUserData(userId);
+  useEffect(() => {
+    if (userData) calcuateCalories(userData);
+  }, [userData, calcuateCalories]);
+
+  return {
+    userData,
   };
 };

--- a/yum-yum/src/hooks/useUser.js
+++ b/yum-yum/src/hooks/useUser.js
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getUserData } from '../services/userApi';
 import { useHomeStore } from '../stores/useHomeStore';
 
-const useUserData = (userId) => {
+export const useUserData = (userId) => {
   // 사용자 데이터 불러오기
   const userQuery = useQuery({
     queryKey: ['user', userId],

--- a/yum-yum/src/pages/home/HomePage.jsx
+++ b/yum-yum/src/pages/home/HomePage.jsx
@@ -168,7 +168,7 @@ export default function HomePage() {
               onUpdateMeal={(id, mealType) => {
                 clearFoods(); // zustand에 이미 저장되어있는 선택값 clear()
                 // selected zustand에 값 추가
-                const copy = mealDataOrigin[id].meals[mealType];
+                const copy = mealDataOrigin[id]?.meals[mealType];
                 copy.map((meal) => addFood(meal));
                 navigate(`/meal/${mealType}/total`, {
                   state: { date: selectedDate },

--- a/yum-yum/src/pages/home/HomePage.jsx
+++ b/yum-yum/src/pages/home/HomePage.jsx
@@ -1,14 +1,12 @@
 /**
  * 메인 페이지
  */
-import React, { useEffect } from 'react';
+import React from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { registerLocale } from 'react-datepicker';
 import { ko } from 'date-fns/locale';
 import { useNavigate } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
-import toast from 'react-hot-toast';
 // 컴포넌트
 import DateHeader from '@/components/common/DateHeader';
 import OnBoarding from '@/components/common/OnBoarding';
@@ -23,9 +21,8 @@ import CalorieMessage from './card/calorie/CalorieMessage';
 import CalorieNutrition from './card/calorie/CalorieNutrition';
 import WeightInput from './modal/WeightInput';
 // 훅
-import { useWeight } from '@/hooks/useWeight';
+import { useWeightModal } from '@/hooks/useWeight';
 import { usePageData } from '@/hooks/useMainPageData';
-import { useUserData } from '@/hooks/useUser';
 // 스토어
 import { useHomeStore } from '@/stores/useHomeStore';
 import { useSelectedFoodsStore } from '@/stores/useSelectedFoodsStore';
@@ -46,73 +43,12 @@ export default function HomePage() {
     setCalendarOpen,
     onboardOpen,
     setOnboardOpen,
-    weightModalOpen,
-    setWeightModalOpen,
-    targetCalories,
-    calcuateCalories,
-    currentWeight,
-    goalWeight,
-    setDailyData,
-    waterData,
-    mealData, // 필요한 부분 파싱된 데이터
   } = useHomeStore();
-  const {
-    saveWeightMutation,
-    selectedDateModal,
-    setSelectedDateModal,
-    selectedDateModalOpen,
-    setSelectedDateModalOpen,
-  } = useWeight(userId, selectedDate);
-  const { dailyData, dailyLoading } = usePageData(userId, selectedDate);
-  const { userData } = useUserData(userId, selectedDate);
+  // hoook 요청
+  const weightModal = useWeightModal(userId, selectedDate);
+  const { waterData, mealData, targetCalories, currentWeight, goalWeight, mealDataOrigin } =
+    usePageData(userId, selectedDate);
   const { clearFoods, addFood } = useSelectedFoodsStore();
-
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors, isValid },
-  } = useForm({
-    defaultValues: { weight: '' },
-    mode: 'onSubmit',
-  });
-
-  // userData가 변경되면 다시 계산
-  useEffect(() => {
-    if (userData) {
-      calcuateCalories(userData);
-    }
-  }, [userData, calcuateCalories]);
-
-  useEffect(() => {
-    if (dailyData) {
-      setDailyData(dailyData, userData);
-    }
-  }, [dailyData]);
-
-  // 체중 저장
-  const onSubmit = async (data) => {
-    try {
-      const saveWeight = saveWeightMutation.mutateAsync({
-        weight: parseFloat(data.weight),
-        date: selectedDateModal,
-      });
-
-      await toast.promise(saveWeight, {
-        loading: '저장하는 중...',
-        success: (response) => {
-          setWeightModalOpen(false);
-          reset();
-          return response?.message || '몸무게가 성공적으로 저장되었습니다!';
-        },
-        error: (error) => {
-          return error?.message || '몸무게 저장에 실패했습니다.';
-        },
-      });
-    } catch (errors) {
-      console.error('체중 저장 실패', errors);
-    }
-  };
 
   return (
     <div className='flex flex-col gap-8 justify-start item-center bg-primary-light w-full h-full min-h-screen'>
@@ -180,33 +116,23 @@ export default function HomePage() {
           <WeightCard
             currentWeight={currentWeight}
             targetWeight={goalWeight}
-            onWeightInput={() => {
-              // 체중 입력 모달 열기 등의 로직
-              setWeightModalOpen(true);
-            }}
+            onWeightInput={weightModal.open}
           />
         </BaseCard>
 
-        {weightModalOpen && (
+        {weightModal.weightModalOpen && (
           <Modal
-            isOpenModal={weightModalOpen}
-            onCloseModal={() => setWeightModalOpen(false)}
+            isOpenModal={weightModal.weightModalOpen}
+            onCloseModal={weightModal.close}
             title='체중 입력'
             showClose={true}
             btnLabel='확인'
-            onBtnClick={handleSubmit(onSubmit)}
+            onBtnClick={weightModal.onSubmit}
           >
             {/* 날짜 선택 부분 */}
-            <MyDateField
-              register={register}
-              errors={errors}
-              selectedDateModal={selectedDateModal}
-              setSelectedDateModal={setSelectedDateModal}
-              selectedDateModalOpen={selectedDateModalOpen}
-              setSelectedDateModalOpen={setSelectedDateModalOpen}
-            />
+            <MyDateField {...weightModal} />
             {/* 몸무게 입력 부분 */}
-            <WeightInput register={register} errors={errors} />
+            <WeightInput register={weightModal.register} errors={weightModal.formState.errors} />
           </Modal>
         )}
 
@@ -242,7 +168,7 @@ export default function HomePage() {
               onUpdateMeal={(id, mealType) => {
                 clearFoods(); // zustand에 이미 저장되어있는 선택값 clear()
                 // selected zustand에 값 추가
-                const copy = dailyData.mealData[id].meals[mealType];
+                const copy = mealDataOrigin[id].meals[mealType];
                 copy.map((meal) => addFood(meal));
                 navigate(`/meal/${mealType}/total`, {
                   state: { date: selectedDate },
@@ -251,7 +177,7 @@ export default function HomePage() {
               onAddWater={() => {
                 navigate(`/water`, { state: { date: selectedDate } });
               }}
-              wholeData={dailyData}
+              // wholeData={{water: waterDataOrigin, meal: mealDataOrigin, weight}}
             />
           </div>
         </BaseCard>

--- a/yum-yum/src/pages/water/WaterPage.jsx
+++ b/yum-yum/src/pages/water/WaterPage.jsx
@@ -108,7 +108,7 @@ export default function WaterPage({ defaultDate = new Date() }) {
       setTargetIntake(data.targetIntake);
 
       // 캐시 무효화
-      queryClient.invalidateQueries(['dailyData', userId]);
+      queryClient.invalidateQueries(['daily-water-data', userId]);
 
       toast.success('설정 저장 완료!');
       setOpenModal(false);
@@ -126,7 +126,7 @@ export default function WaterPage({ defaultDate = new Date() }) {
       // await addWaterIntake(user.uid, formattedSaveDate, waterAmount);
 
       // 캐시 무효화
-      queryClient.invalidateQueries(['dailyData', userId, formattedSaveDate]);
+      queryClient.invalidateQueries(['daily-water-data', userId, formattedSaveDate]);
 
       toast.success('기록이 완료 되었어요!');
 

--- a/yum-yum/src/services/dailyDataApi.js
+++ b/yum-yum/src/services/dailyDataApi.js
@@ -1,6 +1,6 @@
 import { collection, getDocs, query, where } from 'firebase/firestore';
 import { firestore } from './firebase';
-import { getStartDateAndEndDate } from '../utils/dateUtils';
+import { getStartDateAndEndDate, getTodayKey } from '../utils/dateUtils';
 
 export async function getDailyData(userId, selectedDate) {
   const date = new Date(selectedDate).toISOString().split('T')[0];
@@ -49,6 +49,70 @@ export async function getDailyData(userId, selectedDate) {
         mealData: mealData,
         weightData: weightData,
       },
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+}
+
+/**
+ * 식단 검색(하루 단위)
+ * @param {string} userId 유저아이디
+ * @param {Date} selectedDate 선택날짜
+ * @returns
+ */
+export async function getDailyMeal(userId, selectedDate) {
+  const date = getTodayKey(selectedDate);
+
+  try {
+    // 컬랙션 참조 생성
+    const mealRef = collection(firestore, 'users', userId, 'meal');
+    // 음식 쿼리 생성
+    const mealQuery = query(mealRef, where('date', '==', date));
+    // 음식 doc 호출
+    const mealSnap = await getDocs(mealQuery);
+
+    const mealData = mealSnap.docs.map((doc) => {
+      return doc.data();
+    });
+
+    return {
+      success: true,
+      mealData,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+}
+
+/**
+ * 수분 검색(하루 단위)
+ * @param {string} userId 유저아이디
+ * @param {Date} selectedDate 선택날짜
+ * @returns
+ */
+export async function getDailyWater(userId, selectedDate) {
+  const date = getTodayKey(selectedDate);
+  try {
+    const waterRef = collection(firestore, 'users', userId, 'water');
+    const waterQuery = query(waterRef, where('date', '==', date));
+    const waterSnap = await getDocs(waterQuery);
+
+    const waterData = waterSnap.docs.map((doc) => {
+      return doc.data();
+    });
+
+    return {
+      success: true,
+      waterData,
     };
   } catch (error) {
     console.error(error);

--- a/yum-yum/src/stores/useHomeStore.js
+++ b/yum-yum/src/stores/useHomeStore.js
@@ -51,16 +51,23 @@ export const useHomeStore = create(
         });
       },
 
-      // 데이터 정제
-      setDailyData: (data, userData) => {
+      // 음식 데이터 정제
+      setMealData: (data) => {
+        set({
+          mealData: normalizerMeal(data.mealData[0]),
+          originalMealData: data.mealData[0]?.meals,
+        });
+      },
+
+      // 수분 데이터 정제
+      setWaterData: (data, userData) => {
         const water = normalizerWater({
           water: data.waterData[0],
           age: userData?.age,
           gender: userData?.gender,
           targetIntake: userData?.targetIntake,
         });
-        const meal = normalizerMeal(data.mealData[0]);
-        set({ waterData: water, mealData: meal, originalMealData: data.mealData[0]?.meals });
+        set({ waterData: water });
       },
 
       // 초기화

--- a/yum-yum/src/utils/mainDataParser.js
+++ b/yum-yum/src/utils/mainDataParser.js
@@ -104,7 +104,6 @@ const mealSum = (dailySummary, meals) => {
     totalCarbs = 0,
     totalProtein = 0,
     totalFat = 0;
-  // console.log(meals);
   if (!Array.isArray(meals)) {
     Object.keys(meals)?.map((meal) => {
       totalCalories += meal?.calorie ?? 0;


### PR DESCRIPTION
## 📝 작업 개요
- HomePage 컴포넌트에 집중되어 있던 데이터 페칭(fetching)·상태 동기화 로직을 여러 커스텀 훅으로 분리 (useUserData → useHomeUserHook → usePageData)  
- 비즈니스 로직과 UI를 명확히 분리해 가독성·재사용성·유지보수성을 개선
- 기존 usePageData 훅은 식단만 변경해도 모든 API를 한 번에 재호출해 불필요한 중복 요청이 발생했으나, 기능(데이터)별 훅으로 분리해 필요한 API만 호출하도록 개선

## 🔨 작업 내용
- hooks/useUserData.js  
  • React Query로 사용자 데이터 조회 로직 분리  
- hooks/useHomeUserHook.js  
  • 사용자 데이터에 따라 칼로리 계산(useHomeStore.calcuateCalories) 로직 분리  
- hooks/usePageData.js  
  • 일별 물·식단 데이터(useDailyWaterData, useDailyMealData) 조회 및 zustand 상태 동기화 로직 통합  
- HomePage 컴포넌트  
  • 기존에 내부에 있던 useEffect, useQuery, zustand set 함수들을 모두 usePageData 훅으로 이동  
  • 오직 UI 렌더링과 이벤트 핸들링만 남도록 경량화  
------- mutation 업데이트 ----------
-  WaterPage 컴포넌트
  • 캐시 무효화 하는 부분의 캐시 키 이름 수정
  • 'daily-water-data' 라고 water 부분만 검색하게 수정
-  hooks/useDailyMeal.js
  • 캐시 무효화 하는 부분의 캐시 키 이름 수정
  • 'daily-meal-data' 라고 meal 부분만 검색하게 수정

-------------- 이외 -----------------
- import 경로 및 중복 코드 정리

## ✅ 테스트 방법
1. 로그인 후 홈 페이지 진입  
2. 날짜(DatePicker) 변경 → 물·식단·체중·칼로리 차트가 정상 갱신되는지 확인  
3. “체중 입력” 모달 열기 → 몸무게 입력 후 저장 → toast 알림 및 그래프 반영 확인  
4. 식단 추가/수정(기존 선택된 foods 상태 유지) → 새로운 페이지로 정상 네비게이션 확인  
5. 네트워크 탭에서 user/meal/water API 호출이 정상적으로 발생하는지 확인

## 📎 관련 이슈

### 📸 스크린샷(선택)

## 🎯 리뷰 요구사항
- usePageData 훅의 의존성 배열(useEffect)이 적절한지  
- 커스텀 훅 네이밍(useHomeUserHook vs useUserCalories 등) 제안 환영