### PR TITLE
[fix] 홈에서 0칼로리 업데이트 선택 시 토탈 페이지 이동

### DIFF
--- a/yum-yum/src/pages/home/HomePage.jsx
+++ b/yum-yum/src/pages/home/HomePage.jsx
@@ -43,6 +43,7 @@ export default function HomePage() {
     setCalendarOpen,
     onboardOpen,
     setOnboardOpen,
+    originalMealData,
   } = useHomeStore();
   // hoook 요청
   const weightModal = useWeightModal(userId, selectedDate);
@@ -168,10 +169,10 @@ export default function HomePage() {
               onUpdateMeal={(id, mealType) => {
                 clearFoods(); // zustand에 이미 저장되어있는 선택값 clear()
                 // selected zustand에 값 추가
-                const copy = mealDataOrigin[id]?.meals[mealType];
+                const copy = originalMealData?.[mealType];
                 copy.map((meal) => addFood(meal));
                 navigate(`/meal/${mealType}/total`, {
-                  state: { date: selectedDate },
+                  state: { date: selectedDate, formMain: true },
                 });
               }}
               onAddWater={() => {

--- a/yum-yum/src/pages/home/card/nutrition/MealCard.jsx
+++ b/yum-yum/src/pages/home/card/nutrition/MealCard.jsx
@@ -51,7 +51,7 @@ const MealCard = ({
             <CheckButton
               hasData={section.data.foods && section.data.foods.length > 0}
               onClick={() => {
-                if (section.data.calories > 0) {
+                if (section.data.foods) {
                   onUpdateMeal(meals._id, section.key);
                 } else {
                   onAddMeal(meals._id, section.key);


### PR DESCRIPTION

## 📝 작업 개요
- 홈에서 0칼로리만 있는 부분 업데이트 선택 시 추가페이지로 이동을 하고 있음

## 🔨 작업 내용
- `HomePage` 컴포넌트:
     ・ mealDataOrigin -> originalMealData 불러오는 변수 수정
- `MealCard` 컴포넌트
     ・ 칼로리로 update, add 구분하는 부분 음식 리스트(이름) 존재여부로 수정

## ✅ 테스트 방법
1. 칼로리가 0인 음식만 추가
2. 홈에서 칼로리가 0인 음식 수정 버튼 클릭
3. 토탈페이지로 이동하는지 확인

## 📎 관련 이슈
