### PR TITLE
[Refactor:] 리포트 페이지 상태 Zustand 스토어로 관리하도록 변경

### DIFF
--- a/yum-yum/src/pages/report/charts/PieCharts.jsx
+++ b/yum-yum/src/pages/report/charts/PieCharts.jsx
@@ -101,10 +101,15 @@ export default function PieCharts({ data }) {
         verticalAlign='bottom'
         align='center'
         // 범례
-        payload={pieData.map((item, index) => ({
-          value: item.name,
-          type: 'square', // 범례 도형
-        }))}
+        payload={pieData
+          .sort((a, b) => {
+            const order = ['탄수화물', '단백질', '지방'];
+            return order.indexOf(a.name) - order.indexOf(b.name);
+          })
+          .map((item, index) => ({
+            value: item.name,
+            type: 'square',
+          }))}
         wrapperStyle={{
           whiteSpace: 'nowrap', // 줄바꿈 방지
           marginTop: 20,

--- a/yum-yum/src/pages/report/components/ChartArea.jsx
+++ b/yum-yum/src/pages/report/components/ChartArea.jsx
@@ -6,12 +6,11 @@ import PrevDateIcon from '@/assets/icons/icon-left.svg?react';
 import NextDateIcon from '@/assets/icons/icon-right.svg?react';
 
 import { roundTo1, toNum } from '@/utils/nutrientNumber';
-import { parseDateString } from '@/utils/dateUtils';
+import { parseDateString, dateFormatting } from '@/utils/dateUtils';
 
 import { useReportStore } from '@/stores/useReportStore';
 import clsx from 'clsx';
 import DatePicker from 'react-datepicker';
-import { dateFormatting } from '../../../utils/dateUtils';
 
 // 단위 기간별 접두어
 const periodPrefixConfig = {
@@ -43,19 +42,17 @@ const unitConfig = {
 // 단위기간 버튼용
 const periods = ['일간', '주간', '월간'];
 
-export default function ChartArea({
-  originDate,
-  date,
-  unit,
-  value,
-  children,
-  activePeriod,
-  onPeriodChange,
-  prevDate,
-  nextDate,
-  canMove,
-}) {
-  const { setDate, calendarOpen, setCalendarOpen } = useReportStore();
+export default function ChartArea({ originDate, date, unit, value, children }) {
+  const {
+    setDate,
+    calendarOpen,
+    setCalendarOpen,
+    handlePrevDate,
+    handleNextDate,
+    getCanMove,
+    activePeriod,
+    setActivePeriod,
+  } = useReportStore();
 
   // 활성화된 단위기간과 리포트 타입에 맞는 접두어 및 접미어 설정
   const periodPrefix =
@@ -111,7 +108,7 @@ export default function ChartArea({
       {/* 날짜 및 날짜 변경 버튼 */}
       {date && (
         <div className='flex flex-row gap-3 items-center'>
-          <button onClick={prevDate}>
+          <button onClick={() => handlePrevDate(activePeriod)}>
             <PrevDateIcon />
           </button>
 
@@ -154,8 +151,8 @@ export default function ChartArea({
               </>
             )}
           </article>
-          {canMove && (
-            <button onClick={nextDate} disabled={!canMove}>
+          {getCanMove() && (
+            <button onClick={() => handleNextDate(activePeriod)} disabled={!getCanMove()}>
               <NextDateIcon />
             </button>
           )}
@@ -189,7 +186,7 @@ export default function ChartArea({
         {periods.map((period) => (
           <RoundButton
             key={period}
-            onClick={() => onPeriodChange(period)}
+            onClick={() => setActivePeriod(period)}
             variant={activePeriod === period ? 'filled' : 'line'}
           >
             {period}

--- a/yum-yum/src/pages/report/pages/AiReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/AiReportPage.jsx
@@ -24,15 +24,10 @@ import { useQueryClient } from '@tanstack/react-query';
 export default function AiReportPage({
   originDate,
   fullDate,
-  activePeriod,
-  setActivePeriod,
-  prev,
-  next,
-  canMove,
 }) {
   const userId = callUserUid();
 
-  const { searchType, nutrientionReport, setSearchType, setNutrientionReport } = useReportStore();
+  const { searchType, nutrientionReport, setSearchType, setNutrientionReport, activePeriod } = useReportStore();
 
   const parsedDate = parseDateString(originDate);
 
@@ -71,15 +66,7 @@ export default function AiReportPage({
     currentTimePeriod,
     searchType
   );
-
-  const onPrevPeriod = () => {
-    prev();
-  };
-
-  const onNextPeriod = () => {
-    next();
-  };
-
+  
   // Lookbehind / Lookahead
   // 문장 부호 단위로 분리. 강조 구문은 분리안함
   // const splitMarkdownSentences = (text) => {
@@ -94,25 +81,23 @@ export default function AiReportPage({
     setNutrientionReport(data);
   }, [data]);
 
-  useEffect(() => {
-    if(mealsError) {
-      console.log(mealsErrorMsg)
-    }
-  }, [mealsError])
+  // useEffect(() => {
+  //   if(mealsError) {
+  //     console.log(mealsErrorMsg)
+  //   }
+  // }, [mealsError])
+
+  // useEffect(() => {
+  //   console.log(aiErrorMsg)
+  // }, [aiErrorMsg])
 
   return (
     <main className='flex flex-col h-full gap-7.5'>
       <ChartArea
         originDate={originDate}
         date={fullDate}
-        period='일간'
         unit='AI'
         value='1.2'
-        activePeriod={activePeriod}
-        prevDate={onPrevPeriod}
-        nextDate={onNextPeriod}
-        canMove={canMove}
-        onPeriodChange={setActivePeriod}
       >
         <section className='flex flex-col flex-1 align-items justify-center gap-2.5 w-90 pt-5 pb-5 pr-5 pl-5 rounded-2xl text-white bg-[var(--color-primary)] text-center'>
           <article className='flex flex-row items-center justify-center text-lg'>

--- a/yum-yum/src/pages/report/pages/DietReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/DietReportPage.jsx
@@ -30,16 +30,12 @@ import { callUserUid } from '@/utils/localStorage';
 export default function DietReportPage({
   originDate,
   fullDate,
-  activePeriod,
-  setActivePeriod,
-  prev,
-  next,
-  canMove,
 }) {
   // 데이터
   const userId = callUserUid();
   const {
     nutrients,
+    activePeriod,
     mealSortedByCarbs,
     mealSortedByFat,
     mealSortedByProtein,
@@ -68,24 +64,12 @@ export default function DietReportPage({
   const [activeDetailTab, setActiveDetailTab] = useState('영양 정보');
   const DetailTab = [{ name: '영양 정보' }, { name: '영양소 별 음식' }];
 
-  // 이전, 다음 기간 함수
-  const onPrevPeriod = () => {
-    prev();
-  };
-
-  const onNextPeriod = () => {
-    next();
-  };
-
   // 영양소별 음식 아이콘
   const nutritionIcon = {
     탄수화물: <Carbohydrate />,
     단백질: <Protein />,
     지방: <Fat />,
   };
-
-  const isLoading = daliyIsLoading || weeklyIsLoading || monthlyIsLoading;
-  const isError = daliyIsError || weeklyIsError || monthlyIsError;
 
   useEffect(() => {
     let currentData = null;
@@ -153,14 +137,8 @@ export default function DietReportPage({
       <ChartArea
         originDate={originDate}
         date={fullDate}
-        period='일간'
         unit='Kcal'
         value={nutrients?.totalCalories ?? 0}
-        activePeriod={activePeriod}
-        prevDate={onPrevPeriod}
-        nextDate={onNextPeriod}
-        canMove={canMove}
-        onPeriodChange={setActivePeriod}
       >
         {/* 탄단지 비율 차트 */}
         {(daliyIsLoading || weeklyIsLoading || monthlyIsLoading) && (

--- a/yum-yum/src/pages/report/pages/ReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/ReportPage.jsx
@@ -8,17 +8,6 @@ import { useReportStore } from '@/stores/useReportStore';
 
 import {
   getDayOfWeek,
-  todayDate,
-  getStartDateOfWeek,
-  getEndDateOfWeek,
-  getYesterday,
-  getLastMonth,
-  getLastWeek,
-  getNextMonth,
-  getNextWeek,
-  getTomorrow,
-  parseDateString,
-  canMoveDate,
 } from '@/utils/dateUtils';
 
 const reportPath = {
@@ -36,6 +25,7 @@ const reportParam = {
   ai: 'AI 리포트',
 };
 
+// 파라미터 변환
 const tabToParam = {
   식단: 'diet',
   수분: 'water',
@@ -44,15 +34,24 @@ const tabToParam = {
 };
 
 export default function ReportPage() {
-  const { date, setDate, calendarOpen, setCalendarOpen } = useReportStore();
+  const { 
+    // 날짜
+    date, setDate, 
+    // 캘린더
+    calendarOpen, setCalendarOpen, 
+    // 단위 기간 저장
+    activePeriod, setActivePeriod, 
+    // 리포트 종류
+    reportTypes,
+    // 계산
+    getDisplayDate,
+  } = useReportStore();
 
+  // 현재 활성화 된 리포트탭
   const [activeTab, setActiveTab] = useState(null);
-  const reportTypes = [{ name: '식단' }, { name: '수분' }, { name: '체중' }, { name: 'AI 리포트' }];
+  
   const CurrentComponent = reportPath[activeTab];
 
-  // 단위 기간 저장
-  const [activePeriod, setActivePeriod] = useState('일간');
-  
   // 날짜의 요일
   const day = getDayOfWeek(date);
 
@@ -85,68 +84,8 @@ export default function ReportPage() {
     }
   };
 
-  // 표기 날짜 : 일간/주간/월간에 따라 다름
-  const getDisplayDate = (period, date, day) => {
-    // 오늘 날짜, 년, 월, 일 분리
-    const parsedDate = parseDateString(date);
-
-    switch (period) {
-      case '일간':
-        return `${parsedDate.month}월 ${parsedDate.date}일 (${day})`;
-      case '주간': {
-        // 월, 일만 추출
-        const startDate = parseDateString(getStartDateOfWeek(date));
-        const endDate = parseDateString(getEndDateOfWeek(date));
-        return `${startDate.month}월 ${startDate.date}일 ~ ${endDate.month}월 ${endDate.date}일`;
-      }
-      case '월간':
-        return `${parsedDate.year}년 ${parsedDate.month}월`;
-      default:
-        return date;
-    }
-  };
-
   // 표기 날짜
   const fullDate = getDisplayDate(activePeriod, date, day);
-
-  // 다음 단위 기간으로 갈 수 있는지(오늘보다 미래로 가는 것을 막기)
-  const canMove = canMoveDate(date, activePeriod === '일간' ? 1 : activePeriod === '주간' ? 7 : 30);
-
-  // 이전 단위 기간으로
-  const handlePrevDate = () => {
-
-    switch (activePeriod) {
-      case '일간':
-        setDate(getYesterday(date));
-        break;
-      case '주간':
-        setDate(getLastWeek(date));
-        break;
-      case '월간':
-        setDate(getLastMonth(date));
-        break;
-      default:
-        return date;
-    }
-  };
-
-  // 이후 단위 기간으로
-  const handleNextDate = () => {
-
-    switch (activePeriod) {
-      case '일간':
-        setDate(getTomorrow(date));
-        break;
-      case '주간':
-        setDate(getNextWeek(date));
-        break;
-      case '월간':
-        setDate(getNextMonth(date));
-        break;
-      default:
-        return date;
-    }
-  };
 
   useEffect(() => {
     setCalendarOpen(false)
@@ -170,11 +109,6 @@ export default function ReportPage() {
           <CurrentComponent
             originDate={date}
             fullDate={fullDate}
-            activePeriod={activePeriod}
-            setActivePeriod={setActivePeriod}
-            prev={handlePrevDate}
-            next={handleNextDate}
-            canMove={canMove}
           />
         )}
       </main>

--- a/yum-yum/src/pages/report/pages/WaterReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/WaterReportPage.jsx
@@ -15,16 +15,11 @@ import { useReportStore } from '@/stores/useReportStore';
 export default function WaterReportPage({
   originDate,
   fullDate,
-  activePeriod,
-  setActivePeriod,
-  prev,
-  next,
-  canMove,
 }) {
   // 데이터
   const userId = callUserUid();
   
-  const { watersData, totalWaters, setWatersData, setMonthlyWatersData, setCalcuatWatersData, resetWaters } =
+  const { watersData, totalWaters, setWatersData, setMonthlyWatersData, setCalcuatWatersData, resetWaters, activePeriod } =
     useReportStore();
 
   const {
@@ -73,27 +68,13 @@ export default function WaterReportPage({
   //   console.log('waters : ', activePeriod, ':', waters);
   // }, [waters]);
 
-  const onPrevPeriod = () => {
-    prev();
-  };
-
-  const onNextPeriod = () => {
-    next();
-  };
-
   return (
     <main className='flex flex-col gap-7.5'>
       <ChartArea
         originDate={originDate}
         date={fullDate}
-        period='일간'
         unit='L'
         value={totalWaters}
-        activePeriod={activePeriod}
-        prevDate={onPrevPeriod}
-        nextDate={onNextPeriod}
-        canMove={canMove}
-        onPeriodChange={setActivePeriod}
       >
         <LineCharts datas={watersData} activePeriod={activePeriod} unit='L' />
       </ChartArea>

--- a/yum-yum/src/pages/report/pages/WeightReportPage.jsx
+++ b/yum-yum/src/pages/report/pages/WeightReportPage.jsx
@@ -16,22 +16,17 @@ import { callUserUid } from '@/utils/localStorage';
 
 // 스토어
 import { useReportStore } from '@/stores/useReportStore';
-import { useHomeStore } from '@/stores/useHomeStore';
-import { hasCurrentWeight } from '../../../utils/localStorage';
+import { hasCurrentWeight } from '@/utils/localStorage';
 
 export default function WeightReportPage({
   originDate,
   fullDate,
-  activePeriod,
-  setActivePeriod,
-  prev,
-  next,
-  canMove,
 }) {
   const userId = callUserUid();
 
   const {
     currentWeight,
+    activePeriod,
     weightData,
     setCurrentWeight,
     setDailyWeightData,
@@ -57,15 +52,6 @@ export default function WeightReportPage({
     isError: monthlyIsError,
   } = useMonthlyReportData(userId, originDate);
   const { userData } = useUserData(userId, originDate);
-
-  // 기간 변경
-  const onPrevPeriod = () => {
-    prev();
-  };
-
-  const onNextPeriod = () => {
-    next();
-  };
 
   // 기간별 체중과 체중 비교 데이터 설정
   useEffect(() => {
@@ -95,14 +81,8 @@ export default function WeightReportPage({
       <ChartArea
         originDate={originDate}
         date={fullDate}
-        period='일간'
         unit='Kg'
         value={dailyCurrentWeight ?? 0}
-        activePeriod={activePeriod}
-        prevDate={onPrevPeriod}
-        nextDate={onNextPeriod}
-        canMove={canMove}
-        onPeriodChange={setActivePeriod}
       >
         <LineCharts datas={weightData} activePeriod={activePeriod} unit='Kg' />
       </ChartArea>

--- a/yum-yum/src/stores/useReportStore.js
+++ b/yum-yum/src/stores/useReportStore.js
@@ -12,8 +12,10 @@ import {
   getWeightMonthlyData,
   getWeightWeeklyData,
   getWeightYearlyData,
-} from '../utils/reportDataParser';
-import { todayDate } from '../utils/dateUtils';
+} from '@/utils/reportDataParser';
+import { todayDate, getEndDateOfWeek, getStartDateOfWeek, parseDateString  } from '@/utils/dateUtils';
+import { setDate } from 'date-fns';
+import { canMoveDate, getLastMonth, getLastWeek, getNextMonth, getNextWeek, getTomorrow, getYesterday } from '../utils/dateUtils';
 
 const searchConfig = {
   일간: 'daily',
@@ -27,7 +29,9 @@ export const useReportStore = create((set, get) => ({
   date: todayDate(),
 
   // UI
+  activePeriod: '일간',
   calendarOpen: false,
+  reportTypes: [{ name: '식단' }, { name: '수분' }, { name: '체중' }, { name: 'AI 리포트' }],
 
   // 식단 데이터
   originalMealData: null,
@@ -46,7 +50,6 @@ export const useReportStore = create((set, get) => ({
   totalWaters: 0,
 
   // 체중 데이터
-
   originWeightData: null,
 
   currentWeight: 0,
@@ -64,6 +67,7 @@ export const useReportStore = create((set, get) => ({
 
   // UI
   setCalendarOpen: (status) => set({ calendarOpen: status }),
+  setActivePeriod: (period) => set({ activePeriod: period }),
 
   // 식단
   setNutrients: (data, originDate, activePeriod) => {
@@ -166,4 +170,82 @@ export const useReportStore = create((set, get) => ({
       nutrientionReport: data,
     });
   },
+
+
+  // 계산
+
+  // 표기 날짜 : 일간/주간/월간에 따라 다름
+  getDisplayDate: (period, date, day) => {
+    // 오늘 날짜, 년, 월, 일 분리
+    const parsedDate = parseDateString(date);
+
+    switch (period) {
+      case '일간':
+        return `${parsedDate.month}월 ${parsedDate.date}일 (${day})`;
+      case '주간': {
+        // 월, 일만 추출
+        const startDate = parseDateString(getStartDateOfWeek(date));
+        const endDate = parseDateString(getEndDateOfWeek(date));
+        return `${startDate.month}월 ${startDate.date}일 ~ ${endDate.month}월 ${endDate.date}일`;
+      }
+      case '월간':
+        return `${parsedDate.year}년 ${parsedDate.month}월`;
+      default:
+        return date;
+    }
+  },
+
+  // 다음 단위 기간으로 갈 수 있는지(오늘보다 미래로 가는 것을 막기)
+  getCanMove: () => {
+    const { date, activePeriod } = get();
+    const days = activePeriod === '일간' ? 1 : activePeriod === '주간' ? 7 : 30;
+
+    return canMoveDate(date, days);
+  },
+
+  // 이동
+
+  // 이전 단위 기간으로
+  handlePrevDate: (activePeriod) => {
+    set((state) => {
+      let newDate;
+      switch (activePeriod) {
+        case '일간':
+          newDate = getYesterday(state.date);
+          break;
+        case '주간':
+          newDate = getLastWeek(state.date);
+          break;
+        case '월간':
+          newDate = getLastMonth(state.date);
+          break;
+        default:
+          newDate = state.date;
+      }
+      return { date: newDate };
+    });
+  },
+
+    // 이후 단위 기간으로
+  handleNextDate: (activePeriod) => {
+    set((state) => {
+      let newDate;
+
+      switch (activePeriod) {
+        case '일간':
+          newDate = getTomorrow(state.date);
+          break;
+        case '주간':
+          newDate = getNextWeek(state.date);
+          break;
+        case '월간':
+          newDate = getNextMonth(state.date);
+          break;
+        default:
+          newDate = state.date;
+      }
+      return { date: newDate };
+    });
+  },
+
 }));

--- a/yum-yum/src/utils/dateUtils.js
+++ b/yum-yum/src/utils/dateUtils.js
@@ -194,7 +194,7 @@ export const canMoveDate = (date, days) => {
     compareDate = endOfMonth(compareDate);
   }
 
-  today.setHours(0, 0, 0, 0);
+  newDate.setHours(0, 0, 0, 0);
   compareDate.setHours(0, 0, 0, 0);
 
   return newDate <= compareDate;

--- a/yum-yum/src/utils/reportDataParser.js
+++ b/yum-yum/src/utils/reportDataParser.js
@@ -355,7 +355,7 @@ export const getWeightYearlyData = (weightData, selectedDate) => {
           typeof item.value === 'object'
         );
       })
-      .sort((a, b) => new Date(a.date) - new Date(b.date)); // 안전하게 날짜 순으로 정렬
+      .sort((a, b) => new Date(a.date) - new Date(b.date)); // 날짜 순으로 정렬
 
     const lastEntry = monthWeightData[monthWeightData.length - 1];
     const lastWeight = lastEntry ? lastEntry.value.lastchanges?.weight : 0;


### PR DESCRIPTION
## 📝 작업 개요
- 리포트 페이지에서 props로 보내던 상태들을 Zustand에서 관리하도록 수정
-  
## 🔨 작업 내용
- ReportPage 상태 Zustand로 이동
- Props로 보내던 상태들 스토어에서 불러오도록 수정

## ✅ 테스트 방법
- 리포트 페이지들이 각각 잘 작동하는지 확인
- 각 탭/단위 기간이 잘 적용되는지 확인
